### PR TITLE
fix(keyboard): prevent blue border on first row at load

### DIFF
--- a/app/assets/javascripts/tracebook/application.js
+++ b/app/assets/javascripts/tracebook/application.js
@@ -29,20 +29,27 @@
       }
 
       connect() {
-        this.index = 0;
-        this.updateSelection();
+        this.index = -1;
         this.element.addEventListener("keydown", this.handleKeydown.bind(this));
       }
 
       handleKeydown(event) {
         if (["j", "J"].includes(event.key)) {
           event.preventDefault();
-          this.index = Math.min(this.rowTargets.length - 1, this.index + 1);
+          if (this.index === -1) {
+            this.index = 0;
+          } else {
+            this.index = Math.min(this.rowTargets.length - 1, this.index + 1);
+          }
           this.updateSelection();
         }
         if (["k", "K"].includes(event.key)) {
           event.preventDefault();
-          this.index = Math.max(0, this.index - 1);
+          if (this.index === -1) {
+            this.index = 0;
+          } else {
+            this.index = Math.max(0, this.index - 1);
+          }
           this.updateSelection();
         }
         if ([" ", "Enter"].includes(event.key)) {

--- a/lib/tracebook/mappers/anthropic.rb
+++ b/lib/tracebook/mappers/anthropic.rb
@@ -47,7 +47,6 @@ module Tracebook
           end
         end.compact.join("\n\n")
       end
-
     end
   end
 end


### PR DESCRIPTION
## Summary
- Initialize KeyboardController index to -1 instead of 0
- Ensures no row is selected until user navigates with keyboard shortcuts
- Fixes incorrect blue selection border displaying on first row when page loads

## Details
The bug was in the keyboard navigation controller initialization. Previously, the `index` was set to 0 on connect, which meant the first table row would immediately be marked as selected and displayed with a blue border. By initializing to -1, we ensure no selection state until the user explicitly navigates with 'j'/'k' keys.

## Test plan
- [x] Load interactions table page
- [x] Verify first row does not have blue selection border
- [x] Verify 'j' key selects first row
- [x] Verify 'k' key navigates upward from selection
- [x] Verify spacebar toggles checkbox of selected row

Closes #16