### PR TITLE
feat: disable bulk approve button when no interactions selected

### DIFF
--- a/app/assets/javascripts/tracebook/application.js
+++ b/app/assets/javascripts/tracebook/application.js
@@ -18,7 +18,11 @@
 
     class BulkSelectController extends window.Stimulus.Controller {
       static get targets() {
-        return ["toggleAll", "checkbox"];
+        return ["toggleAll", "checkbox", "submitButton"];
+      }
+
+      connect() {
+        this.updateButtonState();
       }
 
       toggleAll() {
@@ -26,6 +30,16 @@
         this.checkboxTargets.forEach((checkbox) => {
           checkbox.checked = checked;
         });
+        this.updateButtonState();
+      }
+
+      checkboxChanged() {
+        this.updateButtonState();
+      }
+
+      updateButtonState() {
+        const anyChecked = this.checkboxTargets.some((cb) => cb.checked);
+        this.submitButtonTarget.disabled = !anyChecked;
       }
     }
 

--- a/app/views/tracebook/interactions/index.html.erb
+++ b/app/views/tracebook/interactions/index.html.erb
@@ -70,7 +70,7 @@
     <%= form_with url: bulk_review_interactions_path, method: :post, data: { controller: "bulk-select" } do %>
       <%= hidden_field_tag :review_state, "approved" %>
       <div class="tb-table-actions">
-        <button type="submit">Bulk Approve</button>
+        <button type="submit" data-bulk-select-target="submitButton" disabled>Bulk Approve</button>
         <button type="submit" class="tb-btn-secondary" formaction="<%= exports_path(format: :csv, filters: @filters.to_h) %>" formmethod="post">Export CSV</button>
       </div>
 
@@ -91,7 +91,7 @@
           <tbody>
             <% @interactions.each do |interaction| %>
               <tr>
-                <td><%= check_box_tag "interaction_ids[]", interaction.id, false, data: { bulk_select_target: "checkbox" } %></td>
+                <td><%= check_box_tag "interaction_ids[]", interaction.id, false, data: { bulk_select_target: "checkbox", action: "change->bulk-select#checkboxChanged" } %></td>
                 <td><%= link_to interaction.created_at.strftime("%Y-%m-%d %H:%M"), interaction_path(interaction) %></td>
                 <td><%= interaction.provider %></td>
                 <td><%= interaction.model %></td>


### PR DESCRIPTION
## Summary
- Adds client-side validation to prevent bulk approval of empty selections
- Disables the submit button until at least one checkbox is selected
- Improves UX by preventing accidental empty submissions

## Changes
- Updated `BulkSelectController` to track checkbox state
- Submit button now disabled by default when no selections present
- Button re-enabled when at least one checkbox is checked

Closes #17