### PR TITLE
fix: Dashboard not mobile-friendly - table overflow and touch targets

### DIFF
--- a/app/assets/stylesheets/tracebook/application.css
+++ b/app/assets/stylesheets/tracebook/application.css
@@ -1560,3 +1560,300 @@ pre {
     max-width: 95%;
   }
 }
+
+/* ==========================================================================
+   Mobile Responsive Styles
+   ========================================================================== */
+
+:root {
+  --tb-touch-target: 44px;
+}
+
+/* Mobile body padding */
+@media (max-width: 767px) {
+  body {
+    padding: 1rem;
+  }
+}
+
+/* KPI Grid - 2 columns on mobile */
+@media (max-width: 767px) {
+  .tb-kpis {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 0.75rem;
+  }
+
+  .tb-kpi {
+    padding: 0.75rem 1rem;
+  }
+
+  .tb-kpi span {
+    font-size: 0.6875rem;
+  }
+
+  .tb-kpi strong {
+    font-size: 1.5rem;
+  }
+
+  .tb-container {
+    gap: 1rem;
+  }
+
+  .tb-header h1 {
+    font-size: 1.25rem;
+  }
+}
+
+/* Collapsible Filters */
+.tb-filter-details {
+  border: 1px solid var(--tb-border);
+  border-radius: var(--tb-radius);
+  background: var(--tb-surface);
+  box-shadow: var(--tb-shadow-sm);
+}
+
+.tb-filter-summary {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  cursor: pointer;
+  font-weight: 500;
+  list-style: none;
+  min-height: var(--tb-touch-target);
+}
+
+.tb-filter-summary::-webkit-details-marker {
+  display: none;
+}
+
+.tb-filter-summary-text {
+  font-size: 0.875rem;
+  color: var(--tb-text);
+}
+
+.tb-filter-count {
+  background: var(--tb-accent);
+  color: white;
+  font-size: 0.75rem;
+  padding: 0.125rem 0.5rem;
+  border-radius: 9999px;
+}
+
+.tb-filter-count:empty {
+  display: none;
+}
+
+.tb-filter-chevron {
+  margin-left: auto;
+  color: var(--tb-muted);
+  transition: transform 0.2s ease;
+}
+
+.tb-filter-details[open] .tb-filter-chevron {
+  transform: rotate(180deg);
+}
+
+.tb-filter-details .tb-filter-form {
+  border: none;
+  border-radius: 0;
+  box-shadow: none;
+  border-top: 1px solid var(--tb-border);
+}
+
+/* Desktop: always show filters, hide summary */
+@media (min-width: 768px) {
+  .tb-filter-summary {
+    display: none;
+  }
+
+  .tb-filter-details .tb-filter-form {
+    display: flex !important;
+    border-top: none;
+  }
+
+  .tb-filter-details {
+    border: none;
+    background: transparent;
+    box-shadow: none;
+  }
+
+  .tb-filters .tb-filter-form {
+    border: 1px solid var(--tb-border);
+    border-radius: var(--tb-radius);
+    background: var(--tb-surface);
+    box-shadow: var(--tb-shadow-sm);
+  }
+}
+
+/* Mobile filter layout */
+@media (max-width: 767px) {
+  .tb-filter-form {
+    padding: 0.75rem;
+  }
+
+  .tb-filter-row {
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .tb-filter-field {
+    max-width: none;
+    width: 100%;
+  }
+
+  .tb-filter-row-secondary {
+    flex-direction: column;
+    padding-top: 0.75rem;
+  }
+
+  .tb-filter-date-range {
+    width: 100%;
+  }
+
+  .tb-date-inputs {
+    flex-wrap: wrap;
+  }
+
+  .tb-date-inputs input[type="date"] {
+    flex: 1;
+    min-width: 120px;
+  }
+
+  .tb-filter-actions {
+    flex-direction: column;
+    width: 100%;
+  }
+
+  .tb-filter-actions button,
+  .tb-filter-actions input[type="submit"],
+  .tb-filter-actions a {
+    width: 100%;
+    justify-content: center;
+    min-height: var(--tb-touch-target);
+    text-align: center;
+  }
+}
+
+/* Touch Targets */
+@media (max-width: 767px) {
+  button,
+  input[type="submit"],
+  .tb-btn-primary,
+  .tb-btn-secondary {
+    min-height: var(--tb-touch-target);
+    padding: 0.625rem 1rem;
+  }
+
+  .tb-table input[type="checkbox"] {
+    width: 1.25rem;
+    height: 1.25rem;
+    min-width: var(--tb-touch-target);
+    min-height: var(--tb-touch-target);
+    margin: 0;
+    cursor: pointer;
+  }
+
+  .tb-pagination a,
+  .tb-pagination span {
+    min-width: var(--tb-touch-target);
+    min-height: var(--tb-touch-target);
+    padding: 0.5rem 0.75rem;
+  }
+}
+
+/* Table Actions Mobile */
+@media (max-width: 767px) {
+  .tb-table-actions {
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .tb-table-actions button {
+    width: 100%;
+    justify-content: center;
+    min-height: var(--tb-touch-target);
+  }
+}
+
+/* Table to Cards Transformation */
+@media (max-width: 767px) {
+  .tb-table thead {
+    position: absolute;
+    left: -9999px;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+  }
+
+  .tb-table,
+  .tb-table tbody {
+    display: block;
+  }
+
+  .tb-table tbody {
+    padding: 0.75rem;
+  }
+
+  .tb-table tbody tr {
+    display: block;
+    padding: 1rem;
+    margin-bottom: 0.75rem;
+    background: var(--tb-surface);
+    border: 1px solid var(--tb-border);
+    border-radius: var(--tb-radius);
+    box-shadow: var(--tb-shadow-sm);
+  }
+
+  .tb-table tbody tr:last-child {
+    margin-bottom: 0;
+  }
+
+  .tb-table td {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.375rem 0;
+    border-bottom: 1px solid var(--tb-border);
+    text-align: right;
+    min-height: 2rem;
+  }
+
+  .tb-table td:last-child {
+    border-bottom: none;
+  }
+
+  .tb-table td::before {
+    content: attr(data-label);
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--tb-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.025em;
+    text-align: left;
+    flex-shrink: 0;
+    margin-right: 1rem;
+  }
+
+  /* Checkbox cell - no label, centered */
+  .tb-table td[data-label="Select"] {
+    justify-content: center;
+    border-bottom: 1px solid var(--tb-border);
+    padding: 0.5rem 0;
+  }
+
+  .tb-table td[data-label="Select"]::before {
+    display: none;
+  }
+
+  /* Pagination inside table wrapper */
+  .tb-table-wrapper .tb-pagination {
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  .tb-table-wrapper .tb-pagination nav {
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+}

--- a/app/controllers/tracebook/actors_controller.rb
+++ b/app/controllers/tracebook/actors_controller.rb
@@ -34,7 +34,7 @@ module Tracebook
       page = (params[:page] || 1).to_i
       total = array.size
       total_pages = (total.to_f / PER_PAGE).ceil
-      page = [[page, 1].max, [total_pages, 1].max].min
+      page = [ [ page, 1 ].max, [ total_pages, 1 ].max ].min
 
       offset = (page - 1) * PER_PAGE
       items = array[offset, PER_PAGE] || []

--- a/app/controllers/tracebook/interactions_controller.rb
+++ b/app/controllers/tracebook/interactions_controller.rb
@@ -85,7 +85,6 @@ module Tracebook
         unique_actors: scope.where.not(actor_id: nil).select(:actor_type, :actor_id).distinct.count
       }
     end
-
   end
 end
 

--- a/app/helpers/tracebook/interactions_helper.rb
+++ b/app/helpers/tracebook/interactions_helper.rb
@@ -104,7 +104,7 @@ module Tracebook
     end
 
     def actor_type_options(actor_types)
-      actor_types.map { |type| [type.demodulize, type] }
+      actor_types.map { |type| [ type.demodulize, type ] }
     end
 
     def fallback_actor_display(interaction)

--- a/app/views/tracebook/actors/index.html.erb
+++ b/app/views/tracebook/actors/index.html.erb
@@ -41,14 +41,14 @@
         <tbody>
           <% @actors.each do |actor| %>
             <tr>
-              <td>
+              <td data-label="Actor">
                 <%= link_to actor_display_name(actor[:actor_type], actor[:actor_id]),
                     actor_path(type: type_to_param(actor[:actor_type]), id: actor[:actor_id]) %>
               </td>
-              <td><%= number_with_delimiter(actor[:sessions_count]) %></td>
-              <td><%= number_with_delimiter(actor[:total_tokens]) %></td>
-              <td><%= cents_to_human(actor[:total_cost_cents]) %></td>
-              <td><%= actor[:last_activity]&.strftime("%Y-%m-%d %H:%M") %></td>
+              <td data-label="Sessions"><%= number_with_delimiter(actor[:sessions_count]) %></td>
+              <td data-label="Tokens"><%= number_with_delimiter(actor[:total_tokens]) %></td>
+              <td data-label="Cost"><%= cents_to_human(actor[:total_cost_cents]) %></td>
+              <td data-label="Last Activity"><%= actor[:last_activity]&.strftime("%Y-%m-%d %H:%M") %></td>
             </tr>
           <% end %>
         </tbody>

--- a/app/views/tracebook/actors/show.html.erb
+++ b/app/views/tracebook/actors/show.html.erb
@@ -47,17 +47,17 @@
         <tbody>
           <% @sessions.each do |session| %>
             <tr>
-              <td>
+              <td data-label="Context">
                 <%= link_to actor_session_path(type: type_to_param(@actor_type), id: @actor_id, session_id: session.session_id) do %>
                   <%= session.context_label %>
                 <% end %>
               </td>
-              <td><%= session.model %></td>
-              <td><%= session.interactions_count %></td>
-              <td><%= number_with_delimiter(session.total_tokens) %></td>
-              <td><%= session.formatted_cost %></td>
-              <td><%= session_review_badge(session) %></td>
-              <td><%= session.last_activity&.strftime("%Y-%m-%d %H:%M") %></td>
+              <td data-label="Model"><%= session.model %></td>
+              <td data-label="Interactions"><%= session.interactions_count %></td>
+              <td data-label="Tokens"><%= number_with_delimiter(session.total_tokens) %></td>
+              <td data-label="Cost"><%= session.formatted_cost %></td>
+              <td data-label="Review"><%= session_review_badge(session) %></td>
+              <td data-label="Last Activity"><%= session.last_activity&.strftime("%Y-%m-%d %H:%M") %></td>
             </tr>
           <% end %>
         </tbody>

--- a/app/views/tracebook/interactions/index.html.erb
+++ b/app/views/tracebook/interactions/index.html.erb
@@ -31,56 +31,67 @@
   </nav>
 
   <section class="tb-filters">
-    <%= form_with url: interactions_path, method: :get, scope: :filters, data: { turbo_frame: "interactions_table" }, class: "tb-filter-form" do |form| %>
-      <div class="tb-filter-row">
-        <div class="tb-filter-field">
-          <%= form.label :provider %>
-          <%= form.select :provider, options_for_select(@providers, @filters[:provider]), include_blank: "All" %>
-        </div>
-        <div class="tb-filter-field">
-          <%= form.label :model %>
-          <%= form.select :model, options_for_select(@models, @filters[:model]), include_blank: "All" %>
-        </div>
-        <div class="tb-filter-field">
-          <%= form.label :project %>
-          <%= form.select :project, options_for_select(@projects, @filters[:project]), include_blank: "All" %>
-        </div>
-        <div class="tb-filter-field">
-          <%= form.label :status %>
-          <%= form.select :status, options_for_select(TraceBook::Interaction.statuses.keys, @filters[:status]), include_blank: "All" %>
-        </div>
-        <div class="tb-filter-field">
-          <%= form.label :review_state, "Review" %>
-          <%= form.select :review_state, options_for_select(TraceBook::Interaction.review_states.keys, @filters[:review_state]), include_blank: "All" %>
-        </div>
-        <div class="tb-filter-field">
-          <%= form.label :tag %>
-          <%= form.text_field :tag, value: @filters[:tag], placeholder: "Filter by tag" %>
-        </div>
-      </div>
-      <div class="tb-filter-row tb-filter-row-secondary">
-        <div class="tb-filter-field">
-          <%= form.label :actor_type, "Actor Type" %>
-          <%= form.select :actor_type, actor_type_options(@actor_types), { include_blank: "All" }, value: @filters[:actor_type] %>
-        </div>
-        <div class="tb-filter-field">
-          <%= form.label :actor_id, "Actor ID" %>
-          <%= form.text_field :actor_id, value: @filters[:actor_id], placeholder: "e.g., 123" %>
-        </div>
-        <div class="tb-filter-field tb-filter-date-range">
-          <%= form.label :from, "Date range" %>
-          <div class="tb-date-inputs">
-            <%= form.date_field :from, value: @filters[:from] %>
-            <span class="tb-date-separator">to</span>
-            <%= form.date_field :to, value: @filters[:to] %>
+    <details class="tb-filter-details" open>
+      <summary class="tb-filter-summary">
+        <span class="tb-filter-summary-text">Filters</span>
+        <% filter_count = @filters.values.count(&:present?) %>
+        <% if filter_count > 0 %>
+          <span class="tb-filter-count"><%= filter_count %></span>
+        <% end %>
+        <span class="tb-filter-chevron">▼</span>
+      </summary>
+
+      <%= form_with url: interactions_path, method: :get, scope: :filters, data: { turbo_frame: "interactions_table" }, class: "tb-filter-form" do |form| %>
+        <div class="tb-filter-row">
+          <div class="tb-filter-field">
+            <%= form.label :provider %>
+            <%= form.select :provider, options_for_select(@providers, @filters[:provider]), include_blank: "All" %>
+          </div>
+          <div class="tb-filter-field">
+            <%= form.label :model %>
+            <%= form.select :model, options_for_select(@models, @filters[:model]), include_blank: "All" %>
+          </div>
+          <div class="tb-filter-field">
+            <%= form.label :project %>
+            <%= form.select :project, options_for_select(@projects, @filters[:project]), include_blank: "All" %>
+          </div>
+          <div class="tb-filter-field">
+            <%= form.label :status %>
+            <%= form.select :status, options_for_select(TraceBook::Interaction.statuses.keys, @filters[:status]), include_blank: "All" %>
+          </div>
+          <div class="tb-filter-field">
+            <%= form.label :review_state, "Review" %>
+            <%= form.select :review_state, options_for_select(TraceBook::Interaction.review_states.keys, @filters[:review_state]), include_blank: "All" %>
+          </div>
+          <div class="tb-filter-field">
+            <%= form.label :tag %>
+            <%= form.text_field :tag, value: @filters[:tag], placeholder: "Filter by tag" %>
           </div>
         </div>
-        <div class="tb-filter-actions">
-          <%= form.submit "Apply Filters" %>
-          <%= link_to "Reset", interactions_path, class: "tb-link" %>
+        <div class="tb-filter-row tb-filter-row-secondary">
+          <div class="tb-filter-field">
+            <%= form.label :actor_type, "Actor Type" %>
+            <%= form.select :actor_type, actor_type_options(@actor_types), { include_blank: "All" }, value: @filters[:actor_type] %>
+          </div>
+          <div class="tb-filter-field">
+            <%= form.label :actor_id, "Actor ID" %>
+            <%= form.text_field :actor_id, value: @filters[:actor_id], placeholder: "e.g., 123" %>
+          </div>
+          <div class="tb-filter-field tb-filter-date-range">
+            <%= form.label :from, "Date range" %>
+            <div class="tb-date-inputs">
+              <%= form.date_field :from, value: @filters[:from] %>
+              <span class="tb-date-separator">to</span>
+              <%= form.date_field :to, value: @filters[:to] %>
+            </div>
+          </div>
+          <div class="tb-filter-actions">
+            <%= form.submit "Apply Filters" %>
+            <%= link_to "Reset", interactions_path, class: "tb-link" %>
+          </div>
         </div>
-      </div>
-    <% end %>
+      <% end %>
+    </details>
   </section>
 
   <section class="tb-table-wrapper">
@@ -109,15 +120,15 @@
           <tbody>
             <% @interactions.each do |interaction| %>
               <tr>
-                <td><%= check_box_tag "interaction_ids[]", interaction.id, false, data: { bulk_select_target: "checkbox", action: "change->bulk-select#checkboxChanged" } %></td>
-                <td><%= link_to interaction.created_at.strftime("%Y-%m-%d %H:%M"), interaction_path(interaction) %></td>
-                <td><%= actor_link(interaction) %></td>
-                <td><%= interaction.provider %></td>
-                <td><%= interaction.model %></td>
-                <td><%= status_badge(interaction.status) %></td>
-                <td><%= review_badge(interaction.review_state) %></td>
-                <td><%= token_breakdown(interaction) %></td>
-                <td><%= cents_to_human(interaction.cost_total_cents) %></td>
+                <td data-label="Select"><%= check_box_tag "interaction_ids[]", interaction.id, false, data: { bulk_select_target: "checkbox", action: "change->bulk-select#checkboxChanged" } %></td>
+                <td data-label="Timestamp"><%= link_to interaction.created_at.strftime("%Y-%m-%d %H:%M"), interaction_path(interaction) %></td>
+                <td data-label="Actor"><%= actor_link(interaction) %></td>
+                <td data-label="Provider"><%= interaction.provider %></td>
+                <td data-label="Model"><%= interaction.model %></td>
+                <td data-label="Status"><%= status_badge(interaction.status) %></td>
+                <td data-label="Review"><%= review_badge(interaction.review_state) %></td>
+                <td data-label="Tokens"><%= token_breakdown(interaction) %></td>
+                <td data-label="Cost"><%= cents_to_human(interaction.cost_total_cents) %></td>
               </tr>
             <% end %>
           </tbody>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Tracebook::Engine.routes.draw do
   resources :interactions, only: [ :index, :show ] do
     post :review, on: :member
     post :bulk_review, on: :collection
-    resources :comments, only: [:create]
+    resources :comments, only: [ :create ]
   end
 
   resources :exports, only: [ :create, :show ]

--- a/db/migrate/20251112000500_create_tracebook_comments.rb
+++ b/db/migrate/20251112000500_create_tracebook_comments.rb
@@ -10,6 +10,6 @@ class CreateTracebookComments < ActiveRecord::Migration[8.0]
       t.timestamps
     end
 
-    add_index :tracebook_comments, [:interaction_id, :created_at]
+    add_index :tracebook_comments, [ :interaction_id, :created_at ]
   end
 end

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -90,7 +90,7 @@ module TraceBook
 
       ordered = Comment.chronological
 
-      assert_equal [comment1.id, comment2.id, comment3.id], ordered.pluck(:id)
+      assert_equal [ comment1.id, comment2.id, comment3.id ], ordered.pluck(:id)
     end
 
     test "interaction.comments returns in chronological order" do


### PR DESCRIPTION
## Summary

- Adds responsive mobile-friendly styles to the TraceBook dashboard
- Uses CSS-only solution with native `<details>` element for collapsible filters
- Transforms tables to card layout on mobile using data-label attributes
- Ensures 44px minimum touch targets for WCAG accessibility compliance

## Test plan

- [ ] View dashboard on mobile viewport (< 768px) - verify table transforms to cards
- [ ] Test filter collapse/expand on mobile - verify `<details>` element works
- [ ] Verify 44px touch targets on buttons, checkboxes, and pagination
- [ ] Confirm KPI grid shows 2 columns on mobile
- [ ] Test on desktop - verify filters show inline, tables remain as tables
- [ ] Run `bundle exec rake test` - all 107 tests should pass

Closes #31