### PR TITLE
feat: add seed_pricing rake task for default LLM pricing rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,22 @@ bin/rails db:migrate
 
 The install generator copies migrations and creates `config/initializers/tracebook.rb`.
 
+### Seed Pricing Rules (Recommended)
+
+TraceBook includes default pricing rules for common LLM providers. Seed them to enable cost tracking:
+
+```bash
+bin/rails tracebook:seed_pricing
+```
+
+This seeds pricing for:
+- **Gemini**: gemini-2.0-flash, gemini-1.5-pro, gemini-1.5-flash
+- **OpenAI**: gpt-4o, gpt-4o-mini, gpt-4-turbo
+- **Anthropic**: claude-3-5-sonnet, claude-3-5-haiku, claude-3-opus
+- **Ollama**: All models (free/local)
+
+The task is idempotent - run it again after gem updates to add new model pricing.
+
 ### Mount the engine
 
 Add to `config/routes.rb`:
@@ -518,7 +534,15 @@ end
 
 ## Cost Tracking
 
-TraceBook automatically calculates costs based on `PricingRule` records. Create pricing rules for your providers/models:
+TraceBook automatically calculates costs based on `PricingRule` records. The easiest way to get started is with the built-in seed task:
+
+```bash
+bin/rails tracebook:seed_pricing
+```
+
+This creates pricing rules for Gemini, OpenAI, Anthropic, and Ollama models. See [Seed Pricing Rules](#seed-pricing-rules-recommended) for details.
+
+For custom models or updated pricing, create rules manually:
 
 ```ruby
 # db/seeds.rb or a migration

--- a/lib/generators/tracebook/install/install_generator.rb
+++ b/lib/generators/tracebook/install/install_generator.rb
@@ -29,6 +29,7 @@ module Tracebook
         say ""
         say "  3. Configure authorization in config/initializers/tracebook.rb"
         say "  4. Set up ActiveRecord encryption (see README)"
+        say "  5. Seed default pricing:  bin/rails tracebook:seed_pricing"
         say ""
       end
     end

--- a/lib/tasks/tracebook_tasks.rake
+++ b/lib/tasks/tracebook_tasks.rake
@@ -1,4 +1,14 @@
-# desc "Explaining what the task does"
-# task :tracebook do
-#   # Task goes here
-# end
+# frozen_string_literal: true
+
+namespace :tracebook do
+  desc "Seed default pricing rules for common LLM providers (Gemini, OpenAI, Anthropic, Ollama)"
+  task seed_pricing: :environment do
+    result = Tracebook::Seeds::PricingRules.seed!
+
+    puts "TraceBook pricing rules seeded!"
+    puts "  Created: #{result[:created]}"
+    puts "  Skipped (already exist): #{result[:skipped]}"
+
+    puts "\nRun again after gem updates to add new model pricing." if result[:created] > 0
+  end
+end

--- a/lib/tracebook.rb
+++ b/lib/tracebook.rb
@@ -10,6 +10,7 @@ require "tracebook/normalized_interaction"
 require "tracebook/redaction_pipeline"
 require "tracebook/pricing"
 require "tracebook/adapters"
+require "tracebook/seeds/pricing_rules"
 
 # TraceBook is a Rails engine for capturing, storing, and reviewing LLM interactions.
 #

--- a/lib/tracebook/seeds/pricing_rules.rb
+++ b/lib/tracebook/seeds/pricing_rules.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module Tracebook
+  module Seeds
+    module PricingRules
+      # All prices are in cents per 1000 tokens.
+      # effective_from is set to provider's approximate release date.
+      DEFAULTS = [
+        # Gemini (Google)
+        { provider: "gemini", model_glob: "gemini-2.0-flash*", input_cents_per_unit: 10, output_cents_per_unit: 40, effective_from: Date.new(2024, 12, 11) },
+        { provider: "gemini", model_glob: "gemini-1.5-pro*", input_cents_per_unit: 125, output_cents_per_unit: 500, effective_from: Date.new(2024, 5, 14) },
+        { provider: "gemini", model_glob: "gemini-1.5-flash*", input_cents_per_unit: 8, output_cents_per_unit: 30, effective_from: Date.new(2024, 5, 14) },
+
+        # OpenAI
+        { provider: "openai", model_glob: "gpt-4o", input_cents_per_unit: 250, output_cents_per_unit: 1000, effective_from: Date.new(2024, 5, 13) },
+        { provider: "openai", model_glob: "gpt-4o-mini*", input_cents_per_unit: 15, output_cents_per_unit: 60, effective_from: Date.new(2024, 7, 18) },
+        { provider: "openai", model_glob: "gpt-4-turbo*", input_cents_per_unit: 1000, output_cents_per_unit: 3000, effective_from: Date.new(2024, 4, 9) },
+
+        # Anthropic
+        { provider: "anthropic", model_glob: "claude-3-5-sonnet*", input_cents_per_unit: 300, output_cents_per_unit: 1500, effective_from: Date.new(2024, 6, 20) },
+        { provider: "anthropic", model_glob: "claude-3-5-haiku*", input_cents_per_unit: 80, output_cents_per_unit: 400, effective_from: Date.new(2024, 10, 22) },
+        { provider: "anthropic", model_glob: "claude-3-opus*", input_cents_per_unit: 1500, output_cents_per_unit: 7500, effective_from: Date.new(2024, 3, 4) },
+
+        # Ollama (local/free)
+        { provider: "ollama", model_glob: "*", input_cents_per_unit: 0, output_cents_per_unit: 0, effective_from: Date.new(2023, 1, 1) }
+      ].freeze
+
+      class << self
+        # Seeds default pricing rules idempotently.
+        # Uses find_or_create_by on provider + model_glob to avoid duplicates.
+        #
+        # @return [Hash] Summary with :created and :skipped counts
+        def seed!
+          created = 0
+          skipped = 0
+
+          DEFAULTS.each do |attrs|
+            rule = Tracebook::PricingRule.find_or_initialize_by(
+              provider: attrs[:provider],
+              model_glob: attrs[:model_glob]
+            )
+
+            if rule.new_record?
+              rule.assign_attributes(
+                input_cents_per_unit: attrs[:input_cents_per_unit],
+                output_cents_per_unit: attrs[:output_cents_per_unit],
+                effective_from: attrs[:effective_from],
+                currency: "USD"
+              )
+              rule.save!
+              created += 1
+            else
+              skipped += 1
+            end
+          end
+
+          { created:, skipped: }
+        end
+      end
+    end
+  end
+end

--- a/test/lib/seeds/pricing_rules_test.rb
+++ b/test/lib/seeds/pricing_rules_test.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Tracebook
+  module Seeds
+    class PricingRulesTest < ActiveSupport::TestCase
+      setup do
+        PricingRule.delete_all
+      end
+
+      test "seeds all default pricing rules" do
+        result = PricingRules.seed!
+
+        assert_equal 10, result[:created]
+        assert_equal 0, result[:skipped]
+        assert_equal 10, PricingRule.count
+      end
+
+      test "is idempotent - skips existing rules on second run" do
+        PricingRules.seed!
+        result = PricingRules.seed!
+
+        assert_equal 0, result[:created]
+        assert_equal 10, result[:skipped]
+        assert_equal 10, PricingRule.count
+      end
+
+      test "seeds all expected providers" do
+        PricingRules.seed!
+
+        providers = PricingRule.pluck(:provider).uniq.sort
+        assert_equal %w[anthropic gemini ollama openai], providers
+      end
+
+      test "seeds correct pricing for gpt-4o" do
+        PricingRules.seed!
+
+        rule = PricingRule.find_by(provider: "openai", model_glob: "gpt-4o")
+        assert_equal 250, rule.input_cents_per_unit
+        assert_equal 1000, rule.output_cents_per_unit
+        assert_equal "USD", rule.currency
+      end
+
+      test "ollama rules have zero cost" do
+        PricingRules.seed!
+
+        rule = PricingRule.find_by(provider: "ollama")
+        assert_equal 0, rule.input_cents_per_unit
+        assert_equal 0, rule.output_cents_per_unit
+      end
+
+      test "all rules have valid effective_from dates" do
+        PricingRules.seed!
+
+        PricingRule.find_each do |rule|
+          assert rule.effective_from.present?, "#{rule.provider}/#{rule.model_glob} missing effective_from"
+          assert rule.effective_from < Date.current, "#{rule.provider}/#{rule.model_glob} has future effective_from"
+        end
+      end
+    end
+  end
+end

--- a/test/tasks/seed_pricing_task_test.rb
+++ b/test/tasks/seed_pricing_task_test.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "rake"
+
+class SeedPricingTaskTest < ActiveSupport::TestCase
+  setup do
+    Tracebook::PricingRule.delete_all
+    Rails.application.load_tasks unless Rake::Task.task_defined?("tracebook:seed_pricing")
+  end
+
+  test "tracebook:seed_pricing task exists" do
+    assert Rake::Task.task_defined?("tracebook:seed_pricing")
+  end
+
+  test "task creates pricing rules" do
+    assert_difference "Tracebook::PricingRule.count", 10 do
+      capture_io { Rake::Task["tracebook:seed_pricing"].invoke }
+    end
+  end
+
+  teardown do
+    Rake::Task["tracebook:seed_pricing"].reenable
+  end
+end


### PR DESCRIPTION
## Summary

- Add `tracebook:seed_pricing` rake task that populates PricingRule records for common LLM providers (Gemini, OpenAI, Anthropic, Ollama)
- Task is idempotent - can be re-run after gem updates without duplicating existing rules
- Updated install generator to inform users about the seed task
- Updated README with documentation

## Details

Addresses issue where cost calculations show $0.00 because no pricing rules exist by default.

**Providers covered:**
- Gemini: gemini-2.0-flash, gemini-1.5-pro, gemini-1.5-flash
- OpenAI: gpt-4o, gpt-4o-mini, gpt-4-turbo  
- Anthropic: claude-3-5-sonnet, claude-3-5-haiku, claude-3-opus
- Ollama: All models (free/local)

## Test plan

- [x] All tests pass (115 runs, 353 assertions, 0 failures)
- [x] Rubocop passes with no offenses
- [x] Unit tests for `Tracebook::Seeds::PricingRules.seed!` method
- [x] Integration test for `tracebook:seed_pricing` rake task
- [x] Idempotency verified (second run skips existing rules)

Closes #29