### PR TITLE
feat: add LlmRedactionJob for async processing and llm_redactor config (#49, #50)

### DIFF
--- a/app/jobs/tracebook/llm_redaction_job.rb
+++ b/app/jobs/tracebook/llm_redaction_job.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+module Tracebook
+  # Background job for async LLM-based PII redaction.
+  #
+  # This job processes interactions that need additional LLM-based redaction
+  # after initial pattern-based redaction. Useful for catching PII that
+  # patterns miss (names, addresses, context-sensitive data).
+  #
+  # Uses pessimistic locking to prevent race conditions and supports
+  # exponential backoff retry on failures.
+  #
+  # @example Enqueue for async processing
+  #   LlmRedactionJob.perform_later(interaction.id)
+  #
+  # @example From retry_async failure mode
+  #   # When LLMBased redactor fails with on_failure: :retry_async,
+  #   # this job can be enqueued to retry later
+  #   LlmRedactionJob.perform_later(interaction.id)
+  class LlmRedactionJob < ApplicationJob
+    queue_as :tracebook_llm_redaction
+
+    # Retry configuration
+    RETRY_CONFIG = {
+      max_attempts: 3,
+      base_delay: 30.seconds,
+      max_delay: 5.minutes
+    }.freeze
+
+    # Retry on standard errors with exponential backoff
+    retry_on StandardError,
+      wait: :polynomially_longer,
+      attempts: RETRY_CONFIG[:max_attempts]
+
+    # Don't retry if interaction was deleted
+    discard_on ActiveRecord::RecordNotFound
+
+    # @param interaction_id [Integer] ID of interaction to process
+    def perform(interaction_id)
+      interaction = Interaction.lock.find(interaction_id)
+
+      # Skip if already processed successfully
+      return if llm_redaction_complete?(interaction)
+
+      redactor = Tracebook.config.llm_redactor
+      return mark_skipped(interaction, "no_llm_redactor_configured") unless redactor
+
+      process_redaction(interaction, redactor)
+    rescue StandardError => error
+      record_failure(interaction, error) if interaction
+      raise # Let ActiveJob handle retry
+    end
+
+    private
+
+    def llm_redaction_complete?(interaction)
+      status = interaction.metadata&.dig("llm_redaction_status")
+      status == "success"
+    end
+
+    def process_redaction(interaction, redactor)
+      # Redact request payload
+      if interaction.request_payload.present?
+        request_json = JSON.generate(interaction.request_payload)
+        redacted_request, = redactor.call(request_json, audit: RedactionAudit.new)
+        interaction.request_payload = JSON.parse(redacted_request)
+      end
+
+      # Redact response payload
+      if interaction.response_payload.present?
+        response_json = JSON.generate(interaction.response_payload)
+        redacted_response, = redactor.call(response_json, audit: RedactionAudit.new)
+        interaction.response_payload = JSON.parse(redacted_response)
+      end
+
+      # Redact text fields
+      if interaction.request_text.present?
+        interaction.request_text, = redactor.call(interaction.request_text, audit: RedactionAudit.new)
+      end
+
+      if interaction.response_text.present?
+        interaction.response_text, = redactor.call(interaction.response_text, audit: RedactionAudit.new)
+      end
+
+      # Update metadata with success status
+      update_metadata(interaction, {
+        "llm_redaction_status" => "success",
+        "llm_redacted_at" => Time.current.iso8601
+      })
+
+      interaction.save!
+    end
+
+    def mark_skipped(interaction, reason)
+      update_metadata(interaction, {
+        "llm_redaction_status" => "skipped",
+        "llm_redaction_reason" => reason
+      })
+      interaction.save!
+    end
+
+    def record_failure(interaction, error)
+      current_attempts = interaction.metadata&.dig("llm_redaction_attempts").to_i
+
+      update_metadata(interaction, {
+        "llm_redaction_status" => "failed",
+        "llm_redaction_error" => error.message,
+        "llm_redaction_attempts" => current_attempts + 1,
+        "llm_redaction_last_attempt" => Time.current.iso8601
+      })
+      interaction.save!
+    rescue StandardError => save_error
+      # Log but don't raise - the original error should propagate
+      Rails.logger.error("[TraceBook] Failed to record LLM redaction failure: #{save_error.message}")
+    end
+
+    def update_metadata(interaction, updates)
+      interaction.metadata = (interaction.metadata || {}).merge(updates)
+    end
+  end
+end

--- a/app/jobs/tracebook/persist_interaction_job.rb
+++ b/app/jobs/tracebook/persist_interaction_job.rb
@@ -93,11 +93,34 @@ module Tracebook
 
       ActiveRecord::Base.transaction do
         Interaction.create!(attributes).tap do |interaction|
-          interaction.actor = normalized.actor if normalized.actor
+          assign_actor(interaction, normalized)
           persist_payloads(interaction, normalized)
           interaction.save! if interaction.changed?
         end
       end
+    end
+
+    def assign_actor(interaction, normalized)
+      # Prefer deserialized actor from GlobalID
+      if normalized.actor_gid.present?
+        interaction.actor = deserialize_actor(normalized)
+      elsif normalized.actor_type.present? && normalized.actor_id.present?
+        # Use serialized type/id when no GlobalID
+        interaction.actor_type = normalized.actor_type
+        interaction.actor_id = normalized.actor_id
+      elsif normalized.actor
+        # Legacy: raw actor object (shouldn't happen with new flow, but backwards compatible)
+        interaction.actor = normalized.actor
+      end
+    end
+
+    def deserialize_actor(normalized)
+      return nil unless normalized.actor_gid.present?
+
+      GlobalID::Locator.locate(normalized.actor_gid)
+    rescue GlobalID::ParseError, ActiveRecord::RecordNotFound => e
+      Rails.logger.warn "TraceBook: Could not deserialize actor from #{normalized.actor_gid}: #{e.message}"
+      nil
     end
 
     def total_tokens(normalized)

--- a/lib/tracebook.rb
+++ b/lib/tracebook.rb
@@ -97,6 +97,38 @@ module Tracebook
       @configuration_finalized = false
     end
 
+    # Serializes an actor for job-safe persistence.
+    #
+    # Converts an ActiveRecord object (or similar) into a hash that can be
+    # safely passed to background jobs. Prefers GlobalID when available for
+    # reliable deserialization, falls back to type/id tuple otherwise.
+    #
+    # @param actor [ActiveRecord::Base, nil] The actor to serialize
+    # @return [Hash] Serialized actor data with :actor_gid or :actor_type/:actor_id keys
+    #
+    # @example With a User model (GlobalID available)
+    #   TraceBook.serialize_actor(User.find(1))
+    #   # => { actor_gid: "gid://myapp/User/1" }
+    #
+    # @example With a plain object (no GlobalID)
+    #   TraceBook.serialize_actor(some_object)
+    #   # => { actor_type: "SomeObject", actor_id: 123 }
+    #
+    # @example With nil
+    #   TraceBook.serialize_actor(nil)
+    #   # => {}
+    def serialize_actor(actor)
+      return {} unless actor
+
+      if actor.respond_to?(:to_global_id)
+        { actor_gid: actor.to_global_id.to_s }
+      elsif actor.respond_to?(:id) && actor.class.respond_to?(:name)
+        { actor_type: actor.class.name, actor_id: actor.id }
+      else
+        {}
+      end
+    end
+
     # Records an LLM interaction.
     #
     # When `config.persist_async` is true, the interaction is enqueued via

--- a/lib/tracebook.rb
+++ b/lib/tracebook.rb
@@ -183,14 +183,18 @@ module Tracebook
     #     latency_ms: 30000
     #   )
     def record!(**attributes)
+      # Build normalized interaction and apply redaction BEFORE job enqueue
+      # This ensures no raw PII ever enters the job queue (critical security fix)
       payload = build_normalized_interaction(attributes)
+      redacted_payload = apply_redaction(payload)
+
       result = Result.new(idempotency_key: attributes[:idempotency_key])
 
       if config.persist_async
-        PersistInteractionJob.perform_later(payload.to_h)
+        PersistInteractionJob.perform_later(redacted_payload.to_h)
         result
       else
-        interaction = PersistInteractionJob.perform_now(payload.to_h)
+        interaction = PersistInteractionJob.perform_now(redacted_payload.to_h)
         Result.new(interaction: interaction, idempotency_key: attributes[:idempotency_key])
       end
     rescue StandardError => error
@@ -208,6 +212,21 @@ module Tracebook
       return unless @configuration_finalized || config.finalized?
 
       raise ConfigurationError, "TraceBook configuration is already finalized"
+    end
+
+    def apply_redaction(normalized)
+      # Serialize actor BEFORE pipeline (deep_dup doesn't handle arbitrary objects well)
+      actor_data = serialize_actor(normalized.actor)
+
+      pipeline = RedactionPipeline.new(config: config)
+      redacted = pipeline.call(normalized)
+
+      # Return new normalized with serialized actor data
+      # Remove :actor (raw object) and :redaction_audit (not serializable by ActiveJob)
+      # redaction_audit is for call-time observability, not persistence
+      NormalizedInteraction.new(
+        **redacted.to_h.except(:actor, :redaction_audit).merge(actor_data)
+      )
     end
 
     def build_normalized_interaction(attributes)

--- a/lib/tracebook/config.rb
+++ b/lib/tracebook/config.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "redactors/patterns"
+
 module Tracebook
   # Configuration object for TraceBook.
   #
@@ -14,7 +16,14 @@ module Tracebook
   #     config.default_currency = "USD"
   #   end
   #
-  # @example With custom redactors
+  # @example Pattern-based redaction DSL
+  #   TraceBook.configure do |config|
+  #     config.redact :email, :phone, :credit_card    # Enable specific patterns
+  #     config.redact_group :api_keys                  # Enable pattern group
+  #     config.redact_pattern(/secret=\w+/, "[SECRET]") # Custom pattern
+  #   end
+  #
+  # @example Legacy custom redactors (lambdas)
   #   TraceBook.configure do |config|
   #     config.custom_redactors += [
   #       ->(payload) { payload.gsub(/api_key=\w+/, "api_key=[REDACTED]") }
@@ -88,6 +97,14 @@ module Tracebook
     #     config.actor_display = ->(actor) { actor.full_name }
     attr_accessor :actor_display
 
+    # @!attribute [r] enabled_patterns
+    #   @return [Array<Symbol>] Pattern symbols enabled via redact DSL
+    attr_reader :enabled_patterns
+
+    # @!attribute [r] custom_patterns
+    #   @return [Array<Redactors::Pattern>] Custom patterns added via redact_pattern
+    attr_reader :custom_patterns
+
     # Creates a new configuration with default values.
     #
     # @return [Config]
@@ -103,6 +120,83 @@ module Tracebook
       @auto_subscribe_active_agent = false
       @per_page = 100
       @actor_display = nil
+      @enabled_patterns = []
+      @custom_patterns = []
+    end
+
+    # Enable one or more built-in redaction patterns.
+    #
+    # @param names [Array<Symbol>] Pattern names from {Redactors::PATTERNS}
+    # @raise [ConfigurationError] if any name is not a valid pattern
+    # @return [void]
+    #
+    # @example Enable email and phone redaction
+    #   config.redact :email, :phone
+    #
+    # @example Enable financial PII
+    #   config.redact :credit_card, :ssn
+    def redact(*names)
+      names.each do |name|
+        unless Redactors::PATTERNS.key?(name)
+          valid_patterns = Redactors::PATTERNS.keys.join(", ")
+          raise ConfigurationError, "Unknown pattern: #{name}. Valid patterns: #{valid_patterns}"
+        end
+        @enabled_patterns << name unless @enabled_patterns.include?(name)
+      end
+    end
+
+    # Enable a group of related patterns.
+    #
+    # @param group_name [Symbol] Group name from {Redactors::PATTERN_GROUPS}
+    # @raise [ConfigurationError] if group name is not valid
+    # @return [void]
+    #
+    # @example Enable all API key patterns
+    #   config.redact_group :api_keys
+    #
+    # @see Redactors::PATTERN_GROUPS
+    def redact_group(group_name)
+      unless Redactors::PATTERN_GROUPS.key?(group_name)
+        valid_groups = Redactors::PATTERN_GROUPS.keys.join(", ")
+        raise ConfigurationError, "Unknown pattern group: #{group_name}. Valid groups: #{valid_groups}"
+      end
+
+      Redactors::PATTERN_GROUPS[group_name].each do |pattern_name|
+        @enabled_patterns << pattern_name unless @enabled_patterns.include?(pattern_name)
+      end
+    end
+
+    # Add a custom regex pattern for redaction.
+    #
+    # @param regex [Regexp] The pattern to match
+    # @param replacement [String] The replacement text (e.g., "[REDACTED]")
+    # @param name [String] Name for audit trail (defaults to "custom_N")
+    # @return [void]
+    #
+    # @example Redact custom API keys
+    #   config.redact_pattern(/myapp_key_\w+/, "[MYAPP_KEY]")
+    #
+    # @example Named custom pattern
+    #   config.redact_pattern(/secret=\w+/, "[SECRET]", name: "app_secret")
+    def redact_pattern(regex, replacement, name: nil)
+      pattern_name = name || "custom_#{@custom_patterns.size + 1}"
+      pattern = Redactors::Pattern.new(
+        regex: regex,
+        replacement: replacement,
+        name: pattern_name
+      )
+      @custom_patterns << pattern
+    end
+
+    # Returns all enabled Pattern objects for redaction.
+    #
+    # Combines patterns enabled via {#redact} and {#redact_group}
+    # with custom patterns from {#redact_pattern}.
+    #
+    # @return [Array<Redactors::Pattern>]
+    def active_patterns
+      patterns = @enabled_patterns.map { |name| Redactors::PATTERNS[name] }
+      patterns + @custom_patterns
     end
 
     # Returns true if configuration has been finalized.
@@ -136,6 +230,8 @@ module Tracebook
       @redactors = @redactors.map { |redactor| redactor }.freeze
       @custom_redactors = @custom_redactors.map { |callable| callable }.freeze
       @export_formats = @export_formats.map(&:to_sym).freeze
+      @enabled_patterns = @enabled_patterns.dup.freeze
+      @custom_patterns = @custom_patterns.dup.freeze
     end
   end
 end

--- a/lib/tracebook/config.rb
+++ b/lib/tracebook/config.rb
@@ -97,6 +97,23 @@ module Tracebook
     #     config.actor_display = ->(actor) { actor.full_name }
     attr_accessor :actor_display
 
+    # @!attribute [rw] llm_redactor
+    #   @return [Redactors::LLMBased, nil] Optional LLM-based redactor for advanced PII detection
+    #   When configured, can be used for async LLM redaction via {LLMRedactionJob}.
+    #   @example Configure with OpenAI
+    #     config.llm_redactor = Tracebook::Redactors::LLMBased.new(
+    #       provider: :openai,
+    #       model: "gpt-4o-mini",
+    #       mode: :sync,
+    #       on_failure: :log_and_continue
+    #     )
+    #   @example Configure with local Ollama (privacy-preserving)
+    #     config.llm_redactor = Tracebook::Redactors::LLMBased.new(
+    #       provider: :ollama,
+    #       model: "llama3.2"
+    #     )
+    attr_accessor :llm_redactor
+
     # @!attribute [r] enabled_patterns
     #   @return [Array<Symbol>] Pattern symbols enabled via redact DSL
     attr_reader :enabled_patterns
@@ -120,6 +137,7 @@ module Tracebook
       @auto_subscribe_active_agent = false
       @per_page = 100
       @actor_display = nil
+      @llm_redactor = nil
       @enabled_patterns = []
       @custom_patterns = []
     end

--- a/lib/tracebook/normalized_interaction.rb
+++ b/lib/tracebook/normalized_interaction.rb
@@ -56,7 +56,11 @@ module Tracebook
     :metadata,
     :actor,
     :parent_id,
-    :session_id
+    :session_id,
+    :actor_type,
+    :actor_id,
+    :actor_gid,
+    :redaction_audit
   ) do
     def initialize(
       provider:,
@@ -76,7 +80,11 @@ module Tracebook
       metadata: {},
       actor: nil,
       parent_id: nil,
-      session_id: nil
+      session_id: nil,
+      actor_type: nil,
+      actor_id: nil,
+      actor_gid: nil,
+      redaction_audit: nil
     )
       super
     end

--- a/lib/tracebook/redaction_pipeline.rb
+++ b/lib/tracebook/redaction_pipeline.rb
@@ -1,8 +1,33 @@
 # frozen_string_literal: true
 
 require "active_support/core_ext/object/deep_dup"
+require_relative "redaction_audit"
 
 module Tracebook
+  # Pipeline for applying PII redaction to LLM interaction data.
+  #
+  # Supports two interfaces:
+  # - New Pattern-based redactors: `call(text, audit:)` returning `[text, audit]`
+  # - Legacy lambda redactors: `call(text)` returning `text`
+  #
+  # The pipeline auto-detects which interface to use based on the callable's
+  # arity and provides backwards compatibility for existing custom_redactors.
+  #
+  # @example Using new Pattern-based redaction
+  #   TraceBook.configure do |config|
+  #     config.redact :email, :phone
+  #   end
+  #   pipeline = RedactionPipeline.new
+  #   result = pipeline.call(normalized_interaction)
+  #   result.redaction_audit.redaction_count  # => 3
+  #
+  # @example Using legacy lambda redactors
+  #   TraceBook.configure do |config|
+  #     config.custom_redactors = [
+  #       ->(text) { text.gsub(/secret=\w+/, "secret=[REDACTED]") }
+  #     ]
+  #   end
+  #
   class RedactionPipeline
     attr_reader :config
 
@@ -12,50 +37,169 @@ module Tracebook
 
     def call(normalized)
       data = normalized.to_h.deep_dup
+      @audit = RedactionAudit.new
 
+      apply_pattern_redactors!(data)
       apply_callable_redactors!(data)
 
+      data[:redaction_audit] = @audit
       NormalizedInteraction.new(**data)
     end
 
     private
 
+    # Apply new-style Pattern redactors from config.active_patterns
+    def apply_pattern_redactors!(data)
+      patterns = config.respond_to?(:active_patterns) ? config.active_patterns : []
+      patterns.each do |pattern|
+        apply_pattern_to_request!(data, pattern)
+        apply_pattern_to_response!(data, pattern)
+        apply_pattern_to_metadata!(data, pattern)
+      end
+    end
+
+    def apply_pattern_to_request!(data, pattern)
+      data[:request_payload], @audit = deep_transform_with_audit(
+        data[:request_payload], pattern, "request_payload"
+      )
+      if data[:request_text].is_a?(String)
+        data[:request_text], @audit = pattern.call(
+          data[:request_text], audit: @audit, field_path: "request_text"
+        )
+      end
+    end
+
+    def apply_pattern_to_response!(data, pattern)
+      data[:response_payload], @audit = deep_transform_with_audit(
+        data[:response_payload], pattern, "response_payload"
+      )
+      if data[:response_text].is_a?(String)
+        data[:response_text], @audit = pattern.call(
+          data[:response_text], audit: @audit, field_path: "response_text"
+        )
+      end
+    end
+
+    def apply_pattern_to_metadata!(data, pattern)
+      data[:metadata], @audit = deep_transform_with_audit(
+        data[:metadata], pattern, "metadata"
+      )
+    end
+
+    def deep_transform_with_audit(value, pattern, path)
+      case value
+      when String
+        pattern.call(value, audit: @audit, field_path: path)
+      when Hash
+        result = {}
+        value.each do |key, nested|
+          result[key], @audit = deep_transform_with_audit(nested, pattern, "#{path}.#{key}")
+        end
+        [ result, @audit ]
+      when Array
+        result = value.map.with_index do |nested, idx|
+          transformed, @audit = deep_transform_with_audit(nested, pattern, "#{path}[#{idx}]")
+          transformed
+        end
+        [ result, @audit ]
+      else
+        [ value, @audit ]
+      end
+    end
+
+    # Apply legacy callable redactors (custom_redactors)
     def apply_callable_redactors!(data)
       redactors = Array(config.redactors) + Array(config.custom_redactors)
       redactors.each do |redactor|
-        apply_to_request!(data, redactor)
-        apply_to_response!(data, redactor)
-        apply_to_metadata!(data, redactor)
+        wrapped = wrap_legacy_redactor(redactor)
+        apply_wrapped_to_request!(data, wrapped)
+        apply_wrapped_to_response!(data, wrapped)
+        apply_wrapped_to_metadata!(data, wrapped)
       end
     end
 
-    def apply_to_request!(data, redactor)
-      data[:request_payload] = deep_transform(data[:request_payload], redactor)
-      data[:request_text] = redactor.call(data[:request_text]) if data[:request_text].is_a?(String)
-    end
+    # Wrap legacy single-arg lambdas to work with audit interface.
+    #
+    # Detects if the redactor is:
+    # - New-style: responds to `call(text, audit:)` (arity -1 with keywords or 2)
+    # - Legacy-style: responds to `call(text)` (arity 1)
+    #
+    # @param redactor [#call] The redactor callable
+    # @return [#call] A wrapped callable with consistent interface
+    def wrap_legacy_redactor(redactor)
+      return redactor if new_style_redactor?(redactor)
 
-    def apply_to_response!(data, redactor)
-      data[:response_payload] = deep_transform(data[:response_payload], redactor)
-      data[:response_text] = redactor.call(data[:response_text]) if data[:response_text].is_a?(String)
-    end
+      # Wrap legacy lambda to track redactions
+      ->(text, audit:, field_path: nil) {
+        return [ text, audit ] unless text.is_a?(String)
 
-    def apply_to_metadata!(data, redactor)
-      data[:metadata] = deep_transform(data[:metadata], redactor)
-    end
+        result = redactor.call(text)
+        updated_audit = audit
 
-    def deep_transform(value, redactor)
-      case value
-      when String
-        redactor.call(value)
-      when Hash
-        value.each_with_object({}) do |(key, nested), memo|
-          memo[key] = deep_transform(nested, redactor)
+        # Track if redaction occurred (text changed)
+        if result != text
+          redactor_name = extract_redactor_name(redactor)
+          updated_audit = audit.record_redaction(redactor_name, field_path || "inline")
         end
-      when Array
-        value.map { |nested| deep_transform(nested, redactor) }
+
+        [ result, updated_audit ]
+      }
+    end
+
+    def new_style_redactor?(redactor)
+      # Pattern objects respond to call(text, audit:, field_path:)
+      return true if redactor.is_a?(Redactors::Pattern)
+
+      # Check if lambda/proc accepts keyword arguments
+      if redactor.respond_to?(:parameters)
+        params = redactor.parameters
+        params.any? { |type, name| type == :keyreq && name == :audit }
       else
-        value
+        false
       end
+    end
+
+    def extract_redactor_name(redactor)
+      if redactor.respond_to?(:name) && redactor.name
+        redactor.name
+      elsif redactor.is_a?(Proc) && redactor.source_location
+        file, line = redactor.source_location
+        "lambda@#{File.basename(file)}:#{line}"
+      else
+        "custom_lambda"
+      end
+    end
+
+    def apply_wrapped_to_request!(data, redactor)
+      data[:request_payload], @audit = deep_transform_with_audit(
+        data[:request_payload], redactor, "request_payload"
+      )
+      if data[:request_text].is_a?(String)
+        data[:request_text], @audit = call_redactor(
+          redactor, data[:request_text], "request_text"
+        )
+      end
+    end
+
+    def apply_wrapped_to_response!(data, redactor)
+      data[:response_payload], @audit = deep_transform_with_audit(
+        data[:response_payload], redactor, "response_payload"
+      )
+      if data[:response_text].is_a?(String)
+        data[:response_text], @audit = call_redactor(
+          redactor, data[:response_text], "response_text"
+        )
+      end
+    end
+
+    def apply_wrapped_to_metadata!(data, redactor)
+      data[:metadata], @audit = deep_transform_with_audit(
+        data[:metadata], redactor, "metadata"
+      )
+    end
+
+    def call_redactor(redactor, text, field_path)
+      redactor.call(text, audit: @audit, field_path: field_path)
     end
   end
 end

--- a/lib/tracebook/redactors.rb
+++ b/lib/tracebook/redactors.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-# Redactors module - patterns and validators will be loaded here
-# TODO: require_relative "redactors/patterns"
-# TODO: require_relative "redactors/validators"
+require_relative "redactors/patterns"
+require_relative "redactors/validators"
+require_relative "redactors/llm_based"
 
 TraceBook = Tracebook unless defined?(TraceBook)

--- a/lib/tracebook/redactors/llm_based.rb
+++ b/lib/tracebook/redactors/llm_based.rb
@@ -1,0 +1,251 @@
+# frozen_string_literal: true
+
+module Tracebook
+  module Redactors
+    # LLM-based redactor for sophisticated PII detection.
+    #
+    # Uses an LLM to identify and redact PII that pattern-based redactors might miss,
+    # such as names, addresses, and context-sensitive information.
+    #
+    # SECURITY WARNING: When using external LLM providers (OpenAI, Anthropic),
+    # the text being redacted is sent to their servers. For maximum privacy,
+    # use a local Ollama instance. Never use external providers for highly
+    # sensitive data without explicit user consent.
+    #
+    # @example Configuration with OpenAI
+    #   TraceBook.configure do |config|
+    #     config.llm_redactor = Tracebook::Redactors::LLMBased.new(
+    #       provider: :openai,
+    #       model: "gpt-4o-mini",
+    #       mode: :sync,
+    #       on_failure: :log_and_continue
+    #     )
+    #   end
+    #
+    # @example Configuration with local Ollama (privacy-preserving)
+    #   TraceBook.configure do |config|
+    #     config.llm_redactor = Tracebook::Redactors::LLMBased.new(
+    #       provider: :ollama,
+    #       model: "llama3.2",
+    #       mode: :sync,
+    #       timeout: 30
+    #     )
+    #   end
+    class LLMBased
+      GUARD_KEY = :tracebook_llm_redaction_guard
+
+      DEFAULT_TIMEOUT = 30
+      DEFAULT_MODE = :sync
+      DEFAULT_ON_FAILURE = :log_and_continue
+
+      VALID_PROVIDERS = %i[openai anthropic ollama].freeze
+      VALID_MODES = %i[sync async].freeze
+      VALID_ON_FAILURE = %i[raise log_and_continue retry_async].freeze
+
+      DEFAULT_PROMPT = <<~PROMPT
+        You are a PII redaction assistant. Your task is to identify and redact
+        personally identifiable information (PII) from the given text.
+
+        Replace PII with appropriate markers:
+        - Names: [NAME]
+        - Addresses: [ADDRESS]
+        - Dates of birth: [DOB]
+        - Account numbers: [ACCOUNT]
+        - Any other PII: [PII]
+
+        IMPORTANT:
+        - Preserve existing redaction markers like [EMAIL], [PHONE], [CARD]
+        - Do NOT redact these markers
+        - Only output the redacted text, nothing else
+        - If no PII is found, output the original text unchanged
+      PROMPT
+
+      attr_reader :provider, :model, :mode, :on_failure, :timeout, :prompt
+
+      # Creates a new LLM-based redactor.
+      #
+      # @param provider [Symbol] LLM provider (:openai, :anthropic, :ollama)
+      # @param model [String] Model identifier (e.g., "gpt-4o-mini", "claude-3-haiku")
+      # @param mode [Symbol] Execution mode (:sync or :async)
+      # @param on_failure [Symbol] Failure handling (:raise, :log_and_continue, :retry_async)
+      # @param timeout [Integer] Request timeout in seconds
+      # @param prompt [String, :default] Custom system prompt or :default
+      def initialize(provider:, model:, mode: DEFAULT_MODE, on_failure: DEFAULT_ON_FAILURE, timeout: DEFAULT_TIMEOUT, prompt: :default)
+        validate_provider!(provider)
+        validate_mode!(mode)
+        validate_on_failure!(on_failure)
+
+        @provider = provider.to_sym
+        @model = model
+        @mode = mode.to_sym
+        @on_failure = on_failure.to_sym
+        @timeout = timeout
+        @prompt = prompt
+      end
+
+      # Redacts PII from text using the configured LLM.
+      #
+      # Uses IsolatedExecutionState guard to prevent infinite recursion when
+      # TraceBook.record! is called within the LLM client (which would trigger
+      # another redaction cycle).
+      #
+      # @param text [String] Text to redact
+      # @param audit [RedactionAudit, nil] Optional audit object to record actions
+      # @param field_path [String, nil] Optional field path for audit context
+      # @return [Array<String, RedactionAudit>] Tuple of [redacted_text, audit]
+      def call(text, audit: RedactionAudit.new, field_path: nil)
+        return [ text, audit ] if guarded?
+        return [ text, audit ] unless text.is_a?(String)
+        return [ text, audit ] if text.length < 10 # Skip very short strings
+
+        with_guard do
+          perform_redaction(text, audit, field_path)
+        end
+      rescue StandardError => error
+        handle_failure(error, text, audit, field_path)
+      end
+
+      # @return [Boolean] true if mode is :sync
+      def sync?
+        mode == :sync
+      end
+
+      # @return [Boolean] true if mode is :async
+      def async?
+        mode == :async
+      end
+
+      private
+
+      def validate_provider!(provider)
+        return if VALID_PROVIDERS.include?(provider.to_sym)
+
+        raise ArgumentError, "Unknown provider: #{provider}. Valid: #{VALID_PROVIDERS.join(', ')}"
+      end
+
+      def validate_mode!(mode)
+        return if VALID_MODES.include?(mode.to_sym)
+
+        raise ArgumentError, "Unknown mode: #{mode}. Valid: #{VALID_MODES.join(', ')}"
+      end
+
+      def validate_on_failure!(on_failure)
+        return if VALID_ON_FAILURE.include?(on_failure.to_sym)
+
+        raise ArgumentError, "Unknown on_failure: #{on_failure}. Valid: #{VALID_ON_FAILURE.join(', ')}"
+      end
+
+      def guarded?
+        ActiveSupport::IsolatedExecutionState[GUARD_KEY] == true
+      end
+
+      def with_guard
+        ActiveSupport::IsolatedExecutionState[GUARD_KEY] = true
+        yield
+      ensure
+        ActiveSupport::IsolatedExecutionState[GUARD_KEY] = false
+      end
+
+      def perform_redaction(text, audit, field_path)
+        response = llm_request(text)
+        redacted = extract_response_text(response)
+
+        # Only record if text actually changed
+        if redacted.present? && redacted != text
+          updated_audit = audit.record_redaction("llm_based", field_path || "inline")
+          [ redacted, updated_audit ]
+        else
+          [ text, audit ]
+        end
+      end
+
+      def llm_request(text)
+        client.chat(
+          model: model,
+          messages: build_messages(text),
+          timeout: timeout
+        )
+      end
+
+      def build_messages(text)
+        [
+          { role: "system", content: system_prompt },
+          { role: "user", content: text }
+        ]
+      end
+
+      def system_prompt
+        prompt == :default ? DEFAULT_PROMPT.strip : prompt
+      end
+
+      def client
+        @client ||= build_client
+      end
+
+      def build_client
+        case provider
+        when :openai
+          require_openai
+          OpenAI::Client.new
+        when :anthropic
+          require_anthropic
+          Anthropic::Client.new
+        when :ollama
+          require_ollama
+          Ollama.new(url: ollama_url)
+        end
+      end
+
+      def require_openai
+        require "openai"
+      rescue LoadError
+        raise LoadError, "The 'ruby-openai' gem is required for OpenAI provider. Add `gem 'ruby-openai'` to your Gemfile."
+      end
+
+      def require_anthropic
+        require "anthropic"
+      rescue LoadError
+        raise LoadError, "The 'anthropic' gem is required for Anthropic provider. Add `gem 'anthropic'` to your Gemfile."
+      end
+
+      def require_ollama
+        require "ollama-ai"
+      rescue LoadError
+        raise LoadError, "The 'ollama-ai' gem is required for Ollama provider. Add `gem 'ollama-ai'` to your Gemfile."
+      end
+
+      def ollama_url
+        ENV.fetch("OLLAMA_URL", "http://localhost:11434")
+      end
+
+      def extract_response_text(response)
+        case provider
+        when :openai
+          response.dig("choices", 0, "message", "content")
+        when :anthropic
+          response.dig("content", 0, "text")
+        when :ollama
+          response.dig("message", "content")
+        end || ""
+      end
+
+      def handle_failure(error, text, audit, field_path)
+        updated_audit = audit.record_redaction("llm_based_failure:#{error.class.name}", field_path || "inline")
+
+        case on_failure
+        when :raise
+          raise
+        when :retry_async
+          # In sync mode, mark for async retry
+          if sync?
+            Rails.logger.warn("[TraceBook] LLM redaction failed, marked for async retry: #{error.message}")
+          end
+          [ text, updated_audit ]
+        else # :log_and_continue
+          Rails.logger.error("[TraceBook] LLM redaction failed: #{error.message}")
+          [ text, updated_audit ]
+        end
+      end
+    end
+  end
+end

--- a/lib/tracebook/redactors/patterns.rb
+++ b/lib/tracebook/redactors/patterns.rb
@@ -1,0 +1,220 @@
+# frozen_string_literal: true
+
+require_relative "validators"
+
+module Tracebook
+  module Redactors
+    # Pattern class for PII redaction with audit support.
+    #
+    # Wraps a regex pattern with optional validation and provides a consistent
+    # call(text, audit:) interface for redaction operations.
+    #
+    # @attr_reader regex [Regexp] The pattern to match
+    # @attr_reader replacement [String] The replacement text (e.g., "[EMAIL]")
+    # @attr_reader name [String] Human-readable pattern name for audit trails
+    # @attr_reader validator [Proc, nil] Optional validation proc for matched text
+    #
+    # @example Basic pattern usage
+    #   pattern = Pattern.new(
+    #     regex: /\b[\w.+-]+@[\w.-]+\.[a-z]{2,}\b/i,
+    #     replacement: "[EMAIL]",
+    #     name: "email"
+    #   )
+    #   audit = RedactionAudit.new
+    #   result = pattern.call("Contact: user@example.com", audit: audit)
+    #   # result => "Contact: [EMAIL]"
+    #   # audit.redaction_count => 1
+    #
+    # @example Pattern with validator
+    #   pattern = Pattern.new(
+    #     regex: /\b\d{4}[\s-]?\d{4}[\s-]?\d{4}[\s-]?\d{4}\b/,
+    #     replacement: "[CARD]",
+    #     name: "credit_card",
+    #     validator: ->(match) { Validators.luhn(match.gsub(/[\s-]/, "")) }
+    #   )
+    #
+    class Pattern
+      attr_reader :regex, :replacement, :name, :validator
+
+      def initialize(regex:, replacement:, name:, validator: nil)
+        @regex = regex
+        @replacement = replacement
+        @name = name
+        @validator = validator
+      end
+
+      # Apply pattern to text and record redactions to audit.
+      #
+      # @param text [String] The text to redact
+      # @param audit [RedactionAudit] Audit object to record redactions
+      # @param field_path [String] Optional field path for audit trail
+      # @return [Array<String, RedactionAudit>] Tuple of [redacted_text, updated_audit]
+      #
+      def call(text, audit:, field_path: nil)
+        return [ text, audit ] unless text.is_a?(String)
+
+        result_text = text.dup
+        updated_audit = audit
+
+        # Find all matches and process in reverse order to preserve positions
+        matches = []
+        text.scan(regex) do
+          match = Regexp.last_match
+          matches << { text: match[0], start: match.begin(0), end: match.end(0) }
+        end
+
+        matches.reverse_each do |match_info|
+          matched_text = match_info[:text]
+
+          # Skip if validator fails
+          next if validator && !validator.call(matched_text)
+
+          # Perform replacement
+          result_text[match_info[:start]...match_info[:end]] = replacement
+
+          # Record to audit
+          path = field_path || "inline"
+          updated_audit = updated_audit.record_redaction(name, path)
+        end
+
+        [ result_text, updated_audit ]
+      end
+    end
+
+    # Standard PII patterns for redaction.
+    #
+    # Each pattern includes a regex, replacement marker, name for audit trails,
+    # and optional validator to reduce false positives.
+    PATTERNS = {
+      # Email addresses - RFC 5322 simplified
+      email: Pattern.new(
+        regex: /\b[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}\b/,
+        replacement: "[EMAIL]",
+        name: "email"
+      ),
+
+      # Phone numbers - US and international formats
+      # Matches: (123) 456-7890, 123-456-7890, +1-123-456-7890, +44 20 7946 0958
+      phone: Pattern.new(
+        regex: /(?:\+\d{1,3}[\s.-]?)?\(?\d{2,4}\)?[\s.-]?\d{3,4}[\s.-]?\d{4}\b/,
+        replacement: "[PHONE]",
+        name: "phone"
+      ),
+
+      # Credit card numbers with Luhn validation
+      # Matches: 4532015112830366, 4532-0151-1283-0366, 4532 0151 1283 0366
+      credit_card: Pattern.new(
+        regex: /\b\d{4}[\s-]?\d{4}[\s-]?\d{4}[\s-]?\d{4}\b/,
+        replacement: "[CARD]",
+        name: "credit_card",
+        validator: ->(match) { Validators.luhn(match.gsub(/[\s-]/, "")) }
+      ),
+
+      # Social Security Numbers with range validation
+      # Matches: 123-45-6789, 123 45 6789, 123456789
+      ssn: Pattern.new(
+        regex: /\b(\d{3})[\s-]?(\d{2})[\s-]?(\d{4})\b/,
+        replacement: "[SSN]",
+        name: "ssn",
+        validator: ->(match) {
+          area = match.gsub(/[\s-]/, "")[0, 3]
+          Validators.ssn_range(area)
+        }
+      ),
+
+      # OpenAI API keys - sk-... format
+      openai_key: Pattern.new(
+        regex: /\bsk-[a-zA-Z0-9]{20,}\b/,
+        replacement: "[OPENAI_KEY]",
+        name: "openai_key"
+      ),
+
+      # Anthropic API keys - sk-ant-... format
+      anthropic_key: Pattern.new(
+        regex: /\bsk-ant-[a-zA-Z0-9-]{20,}\b/,
+        replacement: "[ANTHROPIC_KEY]",
+        name: "anthropic_key"
+      ),
+
+      # AWS access keys - AKIA... format (20 chars)
+      aws_key: Pattern.new(
+        regex: /\b(?:AKIA|ABIA|ACCA|ASIA)[A-Z0-9]{16}\b/,
+        replacement: "[AWS_KEY]",
+        name: "aws_key"
+      ),
+
+      # Stripe API keys - sk_live_..., sk_test_..., pk_live_..., pk_test_...
+      stripe_key: Pattern.new(
+        regex: /\b[sp]k_(?:live|test)_[a-zA-Z0-9]{24,}\b/,
+        replacement: "[STRIPE_KEY]",
+        name: "stripe_key"
+      ),
+
+      # GitHub tokens - ghp_... format (fine-grained PATs)
+      github_token: Pattern.new(
+        regex: /\bghp_[a-zA-Z0-9]{36}\b/,
+        replacement: "[GITHUB_TOKEN]",
+        name: "github_token"
+      ),
+
+      # GitHub PATs - github_pat_... format
+      github_pat: Pattern.new(
+        regex: /\bgithub_pat_[a-zA-Z0-9]{22}_[a-zA-Z0-9]{59}\b/,
+        replacement: "[GITHUB_PAT]",
+        name: "github_pat"
+      ),
+
+      # Bearer tokens in headers
+      bearer_token: Pattern.new(
+        regex: /\bBearer\s+[a-zA-Z0-9._-]{20,}\b/i,
+        replacement: "[BEARER_TOKEN]",
+        name: "bearer_token"
+      ),
+
+      # Basic auth credentials - base64 encoded user:pass
+      basic_auth: Pattern.new(
+        regex: /\bBasic\s+[a-zA-Z0-9+\/]{20,}={0,2}/i,
+        replacement: "[BASIC_AUTH]",
+        name: "basic_auth"
+      ),
+
+      # PEM private keys
+      private_key: Pattern.new(
+        regex: /-----BEGIN\s+(?:RSA\s+)?PRIVATE\s+KEY-----[\s\S]*?-----END\s+(?:RSA\s+)?PRIVATE\s+KEY-----/,
+        replacement: "[PRIVATE_KEY]",
+        name: "private_key"
+      ),
+
+      # IPv4 addresses
+      ipv4: Pattern.new(
+        regex: /\b(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b/,
+        replacement: "[IPV4]",
+        name: "ipv4"
+      ),
+
+      # IPv6 addresses - full and compressed formats
+      ipv6: Pattern.new(
+        regex: /\b(?:[0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}\b|\b(?:[0-9a-fA-F]{1,4}:){1,7}:\b|\b(?:[0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}\b|::(?:[0-9a-fA-F]{1,4}:){0,5}[0-9a-fA-F]{1,4}\b|::1\b/,
+        replacement: "[IPV6]",
+        name: "ipv6"
+      ),
+
+      # JSON Web Tokens (JWT) - three base64url segments
+      jwt: Pattern.new(
+        regex: /\beyJ[a-zA-Z0-9_-]*\.eyJ[a-zA-Z0-9_-]*\.[a-zA-Z0-9_-]+\b/,
+        replacement: "[JWT]",
+        name: "jwt"
+      )
+    }.freeze
+
+    # Pattern groups for convenient batch enabling
+    PATTERN_GROUPS = {
+      pii: %i[email phone ssn],
+      financial: %i[credit_card],
+      api_keys: %i[openai_key anthropic_key aws_key stripe_key github_token github_pat],
+      auth: %i[bearer_token basic_auth jwt],
+      network: %i[ipv4 ipv6],
+      crypto: %i[private_key]
+    }.freeze
+  end
+end

--- a/lib/tracebook/redactors/validators.rb
+++ b/lib/tracebook/redactors/validators.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+module Tracebook
+  module Redactors
+    # Validation methods for PII detection.
+    #
+    # Provides Luhn algorithm for credit card validation and SSN range validation.
+    # Used by Pattern class to reduce false positives in PII detection.
+    module Validators
+      module_function
+
+      # Validates a credit card number using the Luhn algorithm.
+      #
+      # The Luhn algorithm (mod 10) is used to validate credit card numbers.
+      # It detects single-digit errors and most transpositions.
+      #
+      # @param digits [String] The credit card number (digits only, no spaces/dashes)
+      # @return [Boolean] true if the checksum is valid
+      #
+      # @example
+      #   Validators.luhn("4532015112830366") # => true (valid Visa)
+      #   Validators.luhn("1234567890123456") # => false (invalid checksum)
+      def luhn(digits)
+        return false if digits.nil? || digits.empty?
+        return false unless digits.match?(/\A\d+\z/)
+        return false if digits.length < 13 || digits.length > 19
+        return false if digits.chars.uniq.size == 1 # Reject repeated digits (e.g., all zeros)
+
+        sum = 0
+        digits.reverse.each_char.with_index do |char, index|
+          digit = char.to_i
+          if index.odd?
+            doubled = digit * 2
+            digit = doubled > 9 ? doubled - 9 : doubled
+          end
+          sum += digit
+        end
+
+        (sum % 10).zero?
+      end
+
+      # Validates an SSN area number (first 3 digits).
+      #
+      # The Social Security Administration has specific rules for valid area numbers:
+      # - 000 is never valid
+      # - 666 is never valid
+      # - 900-999 were never issued (reserved for advertising/promotional use)
+      #
+      # @param area [String] The first 3 digits of an SSN
+      # @return [Boolean] true if the area number could be valid
+      #
+      # @example
+      #   Validators.ssn_range("078") # => true (valid area)
+      #   Validators.ssn_range("000") # => false (invalid)
+      #   Validators.ssn_range("666") # => false (invalid)
+      #   Validators.ssn_range("900") # => false (invalid - promotional range)
+      def ssn_range(area)
+        return false if area.nil? || area.empty?
+        return false unless area.match?(/\A\d{3}\z/)
+
+        area_num = area.to_i
+
+        # Invalid ranges per SSA rules
+        return false if area_num.zero?        # 000 never valid
+        return false if area_num == 666       # 666 never valid
+        return false if area_num >= 900       # 900-999 never issued
+
+        true
+      end
+    end
+  end
+end

--- a/test/dummy/db/migrate/20251112060837_create_active_storage_tables.active_storage.rb
+++ b/test/dummy/db/migrate/20251112060837_create_active_storage_tables.active_storage.rb
@@ -4,6 +4,9 @@ class CreateActiveStorageTables < ActiveRecord::Migration[7.0]
     # Use Active Record's configured type for primary and foreign keys
     primary_key_type, foreign_key_type = primary_and_foreign_key_types
 
+    # Skip if tables already exist (idempotent for schema:load scenarios)
+    return if table_exists?(:active_storage_blobs)
+
     create_table :active_storage_blobs, id: primary_key_type do |t|
       t.string   :key,          null: false
       t.string   :filename,     null: false

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_11_12_000500) do
+ActiveRecord::Schema[8.1].define(version: 2025_11_12_060837) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false

--- a/test/jobs/llm_redaction_job_test.rb
+++ b/test/jobs/llm_redaction_job_test.rb
@@ -1,0 +1,225 @@
+require "test_helper"
+
+module Tracebook
+  class LlmRedactionJobTest < ActiveSupport::TestCase
+    include ActiveJob::TestHelper
+
+    # Mock LLM redactor for testing
+    class MockRedactor
+      attr_accessor :replacement, :should_fail
+
+      def initialize(replacement: "[LLM_REDACTED]")
+        @replacement = replacement
+        @should_fail = false
+      end
+
+      def call(text, audit: nil, field_path: nil)
+        raise "Mock LLM error" if should_fail
+
+        # Simple mock: replace "SECRET" with replacement
+        redacted = text.gsub(/SECRET/, replacement)
+        [ redacted, audit || RedactionAudit.new ]
+      end
+    end
+
+    setup do
+      clear_enqueued_jobs
+      clear_performed_jobs
+      TraceBook.reset_configuration!
+      Interaction.delete_all
+      @mock_redactor = MockRedactor.new
+    end
+
+    teardown do
+      clear_enqueued_jobs
+      clear_performed_jobs
+      TraceBook.reset_configuration!
+      Interaction.delete_all
+    end
+
+    test "skips when no LLM redactor configured" do
+      TraceBook.configure { |c| c.persist_async = false }
+      interaction = create_interaction(request_text: "Some SECRET data")
+
+      perform_enqueued_jobs do
+        LlmRedactionJob.perform_later(interaction.id)
+      end
+
+      interaction.reload
+      assert_equal "skipped", interaction.metadata["llm_redaction_status"]
+      assert_equal "no_llm_redactor_configured", interaction.metadata["llm_redaction_reason"]
+      assert_equal "Some SECRET data", interaction.request_text # Unchanged
+    end
+
+    test "redacts text fields with LLM redactor" do
+      TraceBook.configure do |c|
+        c.persist_async = false
+        c.llm_redactor = @mock_redactor
+      end
+
+      interaction = create_interaction(
+        request_text: "My SECRET password",
+        response_text: "Your SECRET is safe"
+      )
+
+      perform_enqueued_jobs do
+        LlmRedactionJob.perform_later(interaction.id)
+      end
+
+      interaction.reload
+      assert_equal "success", interaction.metadata["llm_redaction_status"]
+      assert_equal "My [LLM_REDACTED] password", interaction.request_text
+      assert_equal "Your [LLM_REDACTED] is safe", interaction.response_text
+      assert_not_nil interaction.metadata["llm_redacted_at"]
+    end
+
+    test "redacts payload fields with LLM redactor" do
+      TraceBook.configure do |c|
+        c.persist_async = false
+        c.llm_redactor = @mock_redactor
+      end
+
+      interaction = create_interaction(
+        request_payload: { "message" => "Tell me the SECRET" },
+        response_payload: { "content" => "The SECRET is 42" }
+      )
+
+      perform_enqueued_jobs do
+        LlmRedactionJob.perform_later(interaction.id)
+      end
+
+      interaction.reload
+      assert_equal "success", interaction.metadata["llm_redaction_status"]
+      assert_includes interaction.request_payload.to_json, "[LLM_REDACTED]"
+      assert_includes interaction.response_payload.to_json, "[LLM_REDACTED]"
+      assert_not_includes interaction.request_payload.to_json, "SECRET"
+    end
+
+    test "skips already processed interactions" do
+      TraceBook.configure do |c|
+        c.persist_async = false
+        c.llm_redactor = @mock_redactor
+      end
+
+      interaction = create_interaction(
+        request_text: "Some SECRET data",
+        metadata: { "llm_redaction_status" => "success" }
+      )
+
+      # Job should return early without calling redactor
+      @mock_redactor.should_fail = true # Would fail if called
+
+      perform_enqueued_jobs do
+        LlmRedactionJob.perform_later(interaction.id)
+      end
+
+      interaction.reload
+      assert_equal "success", interaction.metadata["llm_redaction_status"]
+      assert_equal "Some SECRET data", interaction.request_text # Unchanged
+    end
+
+    test "records failure on redaction error" do
+      TraceBook.configure do |c|
+        c.persist_async = false
+        c.llm_redactor = @mock_redactor
+      end
+      @mock_redactor.should_fail = true
+
+      interaction = create_interaction(request_text: "Some SECRET data")
+
+      # perform_now with retry_on configured may not re-raise, but should record failure
+      LlmRedactionJob.perform_now(interaction.id)
+
+      interaction.reload
+      assert_equal "failed", interaction.metadata["llm_redaction_status"]
+      assert_equal "Mock LLM error", interaction.metadata["llm_redaction_error"]
+      assert_equal 1, interaction.metadata["llm_redaction_attempts"]
+      assert_not_nil interaction.metadata["llm_redaction_last_attempt"]
+    end
+
+    test "increments attempt count on repeated failures" do
+      TraceBook.configure do |c|
+        c.persist_async = false
+        c.llm_redactor = @mock_redactor
+      end
+      @mock_redactor.should_fail = true
+
+      interaction = create_interaction(
+        request_text: "Some SECRET data",
+        metadata: { "llm_redaction_attempts" => 1 }
+      )
+
+      # perform_now with retry_on configured may not re-raise
+      LlmRedactionJob.perform_now(interaction.id)
+
+      interaction.reload
+      assert_equal 2, interaction.metadata["llm_redaction_attempts"]
+    end
+
+    test "discards job when interaction not found" do
+      TraceBook.configure do |c|
+        c.persist_async = false
+        c.llm_redactor = @mock_redactor
+      end
+
+      # Should not raise - just discarded
+      assert_nothing_raised do
+        perform_enqueued_jobs do
+          LlmRedactionJob.perform_later(999999)
+        end
+      end
+    end
+
+    test "uses pessimistic lock to prevent race conditions" do
+      TraceBook.configure do |c|
+        c.persist_async = false
+        c.llm_redactor = @mock_redactor
+      end
+
+      interaction = create_interaction(request_text: "Some SECRET data")
+
+      # Verify the job uses .lock method (can't easily test concurrency in MiniTest)
+      # This test verifies the job completes successfully with lock
+      perform_enqueued_jobs do
+        LlmRedactionJob.perform_later(interaction.id)
+      end
+
+      interaction.reload
+      assert_equal "success", interaction.metadata["llm_redaction_status"]
+    end
+
+    test "handles nil payloads gracefully" do
+      TraceBook.configure do |c|
+        c.persist_async = false
+        c.llm_redactor = @mock_redactor
+      end
+
+      interaction = create_interaction(
+        request_payload: nil,
+        response_payload: nil,
+        request_text: "SECRET data",
+        response_text: nil
+      )
+
+      perform_enqueued_jobs do
+        LlmRedactionJob.perform_later(interaction.id)
+      end
+
+      interaction.reload
+      assert_equal "success", interaction.metadata["llm_redaction_status"]
+      assert_equal "[LLM_REDACTED] data", interaction.request_text
+    end
+
+    private
+
+    def create_interaction(attrs = {})
+      defaults = {
+        provider: "openai",
+        model: "gpt-4o",
+        status: :success,
+        metadata: {}
+      }
+      Interaction.create!(defaults.merge(attrs))
+    end
+  end
+end

--- a/test/lib/config_test.rb
+++ b/test/lib/config_test.rb
@@ -17,6 +17,8 @@ class TraceBookConfigTest < ActiveSupport::TestCase
     assert_kind_of Array, config.redactors
     assert_equal 0, config.redactors.length  # No default redactors until new Pattern system is built
     assert_equal [], config.custom_redactors
+    assert_equal [], config.enabled_patterns
+    assert_equal [], config.custom_patterns
   end
 
   test "configure yields mutable config then freezes it" do
@@ -40,5 +42,124 @@ class TraceBookConfigTest < ActiveSupport::TestCase
     assert_raises TraceBook::ConfigurationError do
       TraceBook.configure { |_config| }
     end
+  end
+
+  # Config DSL tests (T7)
+
+  test "redact enables individual patterns" do
+    TraceBook.configure do |config|
+      config.redact :email, :phone
+    end
+
+    config = TraceBook.config
+    assert_equal [ :email, :phone ], config.enabled_patterns
+    assert_equal 2, config.active_patterns.size
+    assert config.active_patterns.all? { |p| p.is_a?(Tracebook::Redactors::Pattern) }
+  end
+
+  test "redact raises ConfigurationError for unknown pattern" do
+    assert_raises TraceBook::ConfigurationError do
+      TraceBook.configure do |config|
+        config.redact :bogus_pattern
+      end
+    end
+  end
+
+  test "redact deduplicates patterns" do
+    TraceBook.configure do |config|
+      config.redact :email, :phone
+      config.redact :email  # duplicate
+    end
+
+    config = TraceBook.config
+    assert_equal [ :email, :phone ], config.enabled_patterns
+  end
+
+  test "redact_group enables all patterns in group" do
+    TraceBook.configure do |config|
+      config.redact_group :api_keys
+    end
+
+    config = TraceBook.config
+    expected = [ :openai_key, :anthropic_key, :aws_key, :stripe_key, :github_token, :github_pat ]
+    assert_equal expected, config.enabled_patterns
+  end
+
+  test "redact_group raises ConfigurationError for unknown group" do
+    assert_raises TraceBook::ConfigurationError do
+      TraceBook.configure do |config|
+        config.redact_group :nonexistent_group
+      end
+    end
+  end
+
+  test "redact_group deduplicates with individual redact" do
+    TraceBook.configure do |config|
+      config.redact :openai_key
+      config.redact_group :api_keys  # includes openai_key
+    end
+
+    config = TraceBook.config
+    # openai_key should only appear once
+    assert_equal 1, config.enabled_patterns.count(:openai_key)
+  end
+
+  test "redact_pattern adds custom pattern" do
+    TraceBook.configure do |config|
+      config.redact_pattern(/secret=\w+/, "[SECRET]")
+    end
+
+    config = TraceBook.config
+    assert_equal 1, config.custom_patterns.size
+    pattern = config.custom_patterns.first
+    assert_equal(/secret=\w+/, pattern.regex)
+    assert_equal "[SECRET]", pattern.replacement
+    assert_equal "custom_1", pattern.name
+  end
+
+  test "redact_pattern accepts custom name" do
+    TraceBook.configure do |config|
+      config.redact_pattern(/mykey_\w+/, "[MYKEY]", name: "my_app_key")
+    end
+
+    config = TraceBook.config
+    pattern = config.custom_patterns.first
+    assert_equal "my_app_key", pattern.name
+  end
+
+  test "redact_pattern numbers multiple custom patterns" do
+    TraceBook.configure do |config|
+      config.redact_pattern(/first/, "[FIRST]")
+      config.redact_pattern(/second/, "[SECOND]")
+    end
+
+    config = TraceBook.config
+    assert_equal 2, config.custom_patterns.size
+    assert_equal "custom_1", config.custom_patterns[0].name
+    assert_equal "custom_2", config.custom_patterns[1].name
+  end
+
+  test "active_patterns combines enabled patterns and custom patterns" do
+    TraceBook.configure do |config|
+      config.redact :email
+      config.redact_pattern(/custom/, "[CUSTOM]")
+    end
+
+    config = TraceBook.config
+    active = config.active_patterns
+    assert_equal 2, active.size
+    assert_equal "email", active[0].name
+    assert_equal "custom_1", active[1].name
+  end
+
+  test "enabled_patterns and custom_patterns are frozen after configure" do
+    TraceBook.configure do |config|
+      config.redact :email
+      config.redact_pattern(/x/, "[X]")
+    end
+
+    config = TraceBook.config
+    assert config.enabled_patterns.frozen?
+    assert config.custom_patterns.frozen?
   end
 end

--- a/test/lib/redaction_pipeline_test.rb
+++ b/test/lib/redaction_pipeline_test.rb
@@ -60,5 +60,174 @@ module TraceBook
       assert_equal "response data", redacted.response_text
       assert_equal "secret data", redacted.request_payload["content"]
     end
+
+    # T8: Legacy lambda wrapper tests
+
+    test "legacy lambdas track redactions in audit" do
+      TraceBook.configure do |config|
+        config.custom_redactors = [
+          ->(text) { text.gsub(/secret/, "[REDACTED]") }
+        ]
+      end
+
+      normalized = NormalizedInteraction.new(
+        provider: "openai",
+        model: "gpt-4o",
+        request_payload: {},
+        response_payload: {},
+        request_text: "my secret data",
+        response_text: "another secret here"
+      )
+
+      pipeline = RedactionPipeline.new(config: TraceBook.config)
+      redacted = pipeline.call(normalized)
+
+      assert_equal "my [REDACTED] data", redacted.request_text
+      assert_equal "another [REDACTED] here", redacted.response_text
+      assert_kind_of Tracebook::RedactionAudit, redacted.redaction_audit
+      assert redacted.redaction_audit.redaction_count >= 2
+    end
+
+    test "pattern-based redactors work with audit tracking" do
+      TraceBook.configure do |config|
+        config.redact :email
+      end
+
+      normalized = NormalizedInteraction.new(
+        provider: "openai",
+        model: "gpt-4o",
+        request_payload: { "contact" => "user@example.com" },
+        response_payload: {},
+        request_text: "Email: admin@test.org",
+        response_text: "OK"
+      )
+
+      pipeline = RedactionPipeline.new(config: TraceBook.config)
+      redacted = pipeline.call(normalized)
+
+      assert_equal "Email: [EMAIL]", redacted.request_text
+      assert_equal "[EMAIL]", redacted.request_payload["contact"]
+      assert_equal 2, redacted.redaction_audit.redaction_count
+      assert redacted.redaction_audit.redactors_applied.include?("email")
+    end
+
+    test "combines pattern redactors with legacy lambdas" do
+      TraceBook.configure do |config|
+        config.redact :email
+        config.custom_redactors = [
+          ->(text) { text.gsub(/secret=\w+/, "secret=[HIDDEN]") }
+        ]
+      end
+
+      normalized = NormalizedInteraction.new(
+        provider: "openai",
+        model: "gpt-4o",
+        request_payload: {},
+        response_payload: {},
+        request_text: "user@example.com secret=abc123",
+        response_text: "Done"
+      )
+
+      pipeline = RedactionPipeline.new(config: TraceBook.config)
+      redacted = pipeline.call(normalized)
+
+      assert_equal "[EMAIL] secret=[HIDDEN]", redacted.request_text
+      assert redacted.redaction_audit.redaction_count >= 2
+    end
+
+    test "new-style redactor with audit keyword is not wrapped" do
+      new_style_redactor = ->(text, audit:, field_path: nil) {
+        result = text.gsub(/token=\w+/, "[TOKEN]")
+        updated_audit = result != text ? audit.record_redaction("token", field_path) : audit
+        [ result, updated_audit ]
+      }
+
+      TraceBook.configure do |config|
+        config.custom_redactors = [ new_style_redactor ]
+      end
+
+      normalized = NormalizedInteraction.new(
+        provider: "openai",
+        model: "gpt-4o",
+        request_payload: {},
+        response_payload: {},
+        request_text: "token=xyz789",
+        response_text: "OK"
+      )
+
+      pipeline = RedactionPipeline.new(config: TraceBook.config)
+      redacted = pipeline.call(normalized)
+
+      assert_equal "[TOKEN]", redacted.request_text
+      assert_equal 1, redacted.redaction_audit.redaction_count
+      assert redacted.redaction_audit.redactors_applied.include?("token")
+    end
+
+    test "legacy lambda that does not change text does not record redaction" do
+      TraceBook.configure do |config|
+        config.custom_redactors = [
+          ->(text) { text.gsub(/nonexistent/, "[REDACTED]") }
+        ]
+      end
+
+      normalized = NormalizedInteraction.new(
+        provider: "openai",
+        model: "gpt-4o",
+        request_payload: {},
+        response_payload: {},
+        request_text: "nothing to redact",
+        response_text: "OK"
+      )
+
+      pipeline = RedactionPipeline.new(config: TraceBook.config)
+      redacted = pipeline.call(normalized)
+
+      assert_equal "nothing to redact", redacted.request_text
+      assert_equal 0, redacted.redaction_audit.redaction_count
+    end
+
+    test "returns redaction_audit on result" do
+      normalized = NormalizedInteraction.new(
+        provider: "openai",
+        model: "gpt-4o",
+        request_payload: {},
+        response_payload: {},
+        request_text: "test",
+        response_text: "OK"
+      )
+
+      pipeline = RedactionPipeline.new(config: TraceBook.config)
+      redacted = pipeline.call(normalized)
+
+      assert_not_nil redacted.redaction_audit
+      assert_kind_of Tracebook::RedactionAudit, redacted.redaction_audit
+    end
+
+    test "redacts nested arrays and hashes" do
+      TraceBook.configure do |config|
+        config.redact :email
+      end
+
+      normalized = NormalizedInteraction.new(
+        provider: "openai",
+        model: "gpt-4o",
+        request_payload: {
+          "users" => [
+            { "email" => "a@example.com" },
+            { "email" => "b@example.org" }
+          ]
+        },
+        response_payload: {},
+        request_text: "",
+        response_text: ""
+      )
+
+      pipeline = RedactionPipeline.new(config: TraceBook.config)
+      redacted = pipeline.call(normalized)
+
+      assert_equal "[EMAIL]", redacted.request_payload["users"][0]["email"]
+      assert_equal "[EMAIL]", redacted.request_payload["users"][1]["email"]
+      assert_equal 2, redacted.redaction_audit.redaction_count
+    end
   end
 end

--- a/test/lib/redactors/llm_based_test.rb
+++ b/test/lib/redactors/llm_based_test.rb
@@ -1,0 +1,314 @@
+require "test_helper"
+
+module Tracebook
+  module Redactors
+    class LLMBasedTest < ActiveSupport::TestCase
+      # Mock LLM client for testing
+      class MockClient
+        attr_accessor :response, :should_fail, :request_log
+
+        def initialize
+          @response = nil
+          @should_fail = false
+          @request_log = []
+        end
+
+        def chat(model:, messages:, timeout:)
+          @request_log << { model: model, messages: messages, timeout: timeout }
+          raise "Mock LLM error" if should_fail
+
+          response
+        end
+      end
+
+      setup do
+        @mock_client = MockClient.new
+      end
+
+      # Initialization tests
+
+      test "initializes with valid parameters" do
+        redactor = LLMBased.new(provider: :openai, model: "gpt-4o-mini")
+
+        assert_equal :openai, redactor.provider
+        assert_equal "gpt-4o-mini", redactor.model
+        assert_equal :sync, redactor.mode
+        assert_equal :log_and_continue, redactor.on_failure
+        assert_equal 30, redactor.timeout
+      end
+
+      test "raises on invalid provider" do
+        error = assert_raises(ArgumentError) do
+          LLMBased.new(provider: :invalid, model: "model")
+        end
+
+        assert_includes error.message, "Unknown provider: invalid"
+        assert_includes error.message, "openai"
+      end
+
+      test "raises on invalid mode" do
+        error = assert_raises(ArgumentError) do
+          LLMBased.new(provider: :openai, model: "model", mode: :invalid)
+        end
+
+        assert_includes error.message, "Unknown mode: invalid"
+      end
+
+      test "raises on invalid on_failure" do
+        error = assert_raises(ArgumentError) do
+          LLMBased.new(provider: :openai, model: "model", on_failure: :invalid)
+        end
+
+        assert_includes error.message, "Unknown on_failure: invalid"
+      end
+
+      test "accepts custom prompt" do
+        redactor = LLMBased.new(
+          provider: :openai,
+          model: "gpt-4o-mini",
+          prompt: "Custom prompt"
+        )
+
+        assert_equal "Custom prompt", redactor.prompt
+      end
+
+      # Mode tests
+
+      test "sync? returns true when mode is sync" do
+        redactor = LLMBased.new(provider: :openai, model: "model", mode: :sync)
+        assert redactor.sync?
+        assert_not redactor.async?
+      end
+
+      test "async? returns true when mode is async" do
+        redactor = LLMBased.new(provider: :openai, model: "model", mode: :async)
+        assert redactor.async?
+        assert_not redactor.sync?
+      end
+
+      # Guard protection tests
+
+      test "guard prevents infinite recursion" do
+        redactor = LLMBased.new(provider: :openai, model: "gpt-4o-mini")
+        redactor.instance_variable_set(:@client, @mock_client)
+        @mock_client.response = openai_response("Redacted text")
+
+        # First call should work
+        ActiveSupport::IsolatedExecutionState[LLMBased::GUARD_KEY] = false
+        result1, = redactor.call("Some PII text here")
+
+        # Simulate nested call (guard should prevent)
+        ActiveSupport::IsolatedExecutionState[LLMBased::GUARD_KEY] = true
+        result2, = redactor.call("Another PII text")
+
+        assert_equal "Redacted text", result1
+        assert_equal "Another PII text", result2 # Unchanged due to guard
+      ensure
+        ActiveSupport::IsolatedExecutionState[LLMBased::GUARD_KEY] = false
+      end
+
+      test "guard is cleared after successful call" do
+        redactor = LLMBased.new(provider: :openai, model: "gpt-4o-mini")
+        redactor.instance_variable_set(:@client, @mock_client)
+        @mock_client.response = openai_response("Redacted")
+
+        redactor.call("Some text here")
+
+        assert_not ActiveSupport::IsolatedExecutionState[LLMBased::GUARD_KEY]
+      end
+
+      test "guard is cleared after failed call" do
+        redactor = LLMBased.new(provider: :openai, model: "gpt-4o-mini", on_failure: :log_and_continue)
+        redactor.instance_variable_set(:@client, @mock_client)
+        @mock_client.should_fail = true
+
+        redactor.call("Some text here")
+
+        assert_not ActiveSupport::IsolatedExecutionState[LLMBased::GUARD_KEY]
+      end
+
+      # Redaction tests
+
+      test "redacts text via LLM" do
+        redactor = LLMBased.new(provider: :openai, model: "gpt-4o-mini")
+        redactor.instance_variable_set(:@client, @mock_client)
+        @mock_client.response = openai_response("Hello [NAME], how are you?")
+
+        result, audit = redactor.call("Hello John Smith, how are you?")
+
+        assert_equal "Hello [NAME], how are you?", result
+        assert_equal 1, audit.redaction_count
+        assert_includes audit.redactors_applied, "llm_based"
+      end
+
+      test "returns original text when no changes" do
+        redactor = LLMBased.new(provider: :openai, model: "gpt-4o-mini")
+        redactor.instance_variable_set(:@client, @mock_client)
+        @mock_client.response = openai_response("No PII here")
+
+        result, audit = redactor.call("No PII here")
+
+        assert_equal "No PII here", result
+        assert_equal 0, audit.redaction_count
+      end
+
+      test "skips very short strings" do
+        redactor = LLMBased.new(provider: :openai, model: "gpt-4o-mini")
+        redactor.instance_variable_set(:@client, @mock_client)
+
+        result, = redactor.call("Hi")
+
+        assert_equal "Hi", result
+        assert_empty @mock_client.request_log # No LLM call made
+      end
+
+      test "skips non-string input" do
+        redactor = LLMBased.new(provider: :openai, model: "gpt-4o-mini")
+        redactor.instance_variable_set(:@client, @mock_client)
+
+        result, = redactor.call(12345)
+
+        assert_equal 12345, result
+        assert_empty @mock_client.request_log
+      end
+
+      # Audit tracking tests
+
+      test "records redaction in audit with field_path" do
+        redactor = LLMBased.new(provider: :openai, model: "gpt-4o-mini")
+        redactor.instance_variable_set(:@client, @mock_client)
+        @mock_client.response = openai_response("[NAME] lives at [ADDRESS]")
+
+        _, audit = redactor.call("John lives at 123 Main St", field_path: "messages.0.content")
+
+        assert_equal 1, audit.redaction_count
+        assert_includes audit.redactors_applied, "llm_based"
+      end
+
+      # Failure handling tests
+
+      test "on_failure :log_and_continue returns original text" do
+        redactor = LLMBased.new(
+          provider: :openai,
+          model: "gpt-4o-mini",
+          on_failure: :log_and_continue
+        )
+        redactor.instance_variable_set(:@client, @mock_client)
+        @mock_client.should_fail = true
+
+        result, audit = redactor.call("John Smith secret data")
+
+        assert_equal "John Smith secret data", result
+        assert audit.redactors_applied.any? { |r| r.include?("llm_based_failure") }
+      end
+
+      test "on_failure :raise re-raises exception" do
+        redactor = LLMBased.new(
+          provider: :openai,
+          model: "gpt-4o-mini",
+          on_failure: :raise
+        )
+        redactor.instance_variable_set(:@client, @mock_client)
+        @mock_client.should_fail = true
+
+        assert_raises(RuntimeError) do
+          redactor.call("Some text here")
+        end
+      end
+
+      test "on_failure :retry_async returns original text" do
+        redactor = LLMBased.new(
+          provider: :openai,
+          model: "gpt-4o-mini",
+          on_failure: :retry_async
+        )
+        redactor.instance_variable_set(:@client, @mock_client)
+        @mock_client.should_fail = true
+
+        result, audit = redactor.call("John Smith data")
+
+        assert_equal "John Smith data", result
+        assert audit.redactors_applied.any? { |r| r.include?("llm_based_failure") }
+      end
+
+      # Provider abstraction tests
+
+      test "extracts openai response format" do
+        redactor = LLMBased.new(provider: :openai, model: "gpt-4o-mini")
+        redactor.instance_variable_set(:@client, @mock_client)
+        @mock_client.response = openai_response("Redacted OpenAI")
+
+        result, = redactor.call("Original text here")
+
+        assert_equal "Redacted OpenAI", result
+      end
+
+      test "extracts anthropic response format" do
+        redactor = LLMBased.new(provider: :anthropic, model: "claude-3-haiku")
+        redactor.instance_variable_set(:@client, @mock_client)
+        @mock_client.response = anthropic_response("Redacted Anthropic")
+
+        result, = redactor.call("Original text here")
+
+        assert_equal "Redacted Anthropic", result
+      end
+
+      test "extracts ollama response format" do
+        redactor = LLMBased.new(provider: :ollama, model: "llama3.2")
+        redactor.instance_variable_set(:@client, @mock_client)
+        @mock_client.response = ollama_response("Redacted Ollama")
+
+        result, = redactor.call("Original text here")
+
+        assert_equal "Redacted Ollama", result
+      end
+
+      # System prompt tests
+
+      test "uses default prompt when prompt is :default" do
+        redactor = LLMBased.new(provider: :openai, model: "gpt-4o-mini")
+        redactor.instance_variable_set(:@client, @mock_client)
+        @mock_client.response = openai_response("Redacted")
+
+        redactor.call("Some PII text")
+
+        messages = @mock_client.request_log.first[:messages]
+        system_message = messages.find { |m| m[:role] == "system" }
+
+        assert_includes system_message[:content], "PII redaction assistant"
+        assert_includes system_message[:content], "[NAME]"
+      end
+
+      test "uses custom prompt when provided" do
+        redactor = LLMBased.new(
+          provider: :openai,
+          model: "gpt-4o-mini",
+          prompt: "Custom redaction rules"
+        )
+        redactor.instance_variable_set(:@client, @mock_client)
+        @mock_client.response = openai_response("Redacted")
+
+        redactor.call("Some PII text")
+
+        messages = @mock_client.request_log.first[:messages]
+        system_message = messages.find { |m| m[:role] == "system" }
+
+        assert_equal "Custom redaction rules", system_message[:content]
+      end
+
+      private
+
+      def openai_response(content)
+        { "choices" => [{ "message" => { "content" => content } }] }
+      end
+
+      def anthropic_response(content)
+        { "content" => [{ "text" => content }] }
+      end
+
+      def ollama_response(content)
+        { "message" => { "content" => content } }
+      end
+    end
+  end
+end

--- a/test/tracebook_test.rb
+++ b/test/tracebook_test.rb
@@ -4,4 +4,46 @@ class TracebookTest < ActiveSupport::TestCase
   test "it has a version number" do
     assert Tracebook::VERSION
   end
+
+  test "serialize_actor returns empty hash for nil" do
+    assert_equal({}, Tracebook.serialize_actor(nil))
+  end
+
+  test "serialize_actor extracts global_id when available" do
+    global_id = Object.new
+    global_id.define_singleton_method(:to_s) { "gid://app/User/123" }
+
+    actor = Object.new
+    actor.define_singleton_method(:to_global_id) { global_id }
+
+    result = Tracebook.serialize_actor(actor)
+
+    assert_equal({ actor_gid: "gid://app/User/123" }, result)
+  end
+
+  test "serialize_actor falls back to type/id tuple when no global_id" do
+    actor_class = Class.new do
+      def self.name
+        "CustomActor"
+      end
+    end
+
+    actor = actor_class.new
+    actor.define_singleton_method(:respond_to?) do |method|
+      method != :to_global_id && super(method)
+    end
+    actor.define_singleton_method(:id) { 456 }
+
+    result = Tracebook.serialize_actor(actor)
+
+    assert_equal({ actor_type: "CustomActor", actor_id: 456 }, result)
+  end
+
+  test "serialize_actor returns empty hash for non-serializable objects" do
+    actor = Object.new
+
+    result = Tracebook.serialize_actor(actor)
+
+    assert_equal({}, result)
+  end
 end

--- a/test/tracebook_test.rb
+++ b/test/tracebook_test.rb
@@ -46,4 +46,131 @@ class TracebookTest < ActiveSupport::TestCase
 
     assert_equal({}, result)
   end
+
+  # T10: Redaction timing tests
+
+  test "record! redacts PII before job enqueue with sync mode" do
+    TraceBook.reset_configuration!
+    Tracebook::Interaction.delete_all
+    TraceBook.configure do |config|
+      config.redact :email
+      config.persist_async = false  # Test with sync mode to verify result
+    end
+
+    result = TraceBook.record!(
+      provider: "openai",
+      model: "gpt-4o",
+      request_text: "Contact user@example.com",
+      response_text: "OK"
+    )
+
+    interaction = result.interaction
+    assert_not_nil interaction
+    assert_equal "Contact [EMAIL]", interaction.request_text
+    assert_not_includes interaction.request_text.to_s, "user@example.com"
+  ensure
+    TraceBook.reset_configuration!
+    Tracebook::Interaction.delete_all
+  end
+
+  test "record! no PII in persisted data with patterns enabled" do
+    TraceBook.reset_configuration!
+    Tracebook::Interaction.delete_all
+    TraceBook.configure do |config|
+      config.redact :email, :phone
+      config.persist_async = false
+    end
+
+    result = TraceBook.record!(
+      provider: "openai",
+      model: "gpt-4o",
+      request_payload: {
+        "messages" => [
+          { "content" => "Email: test@email.org, Phone: (555) 123-4567" }
+        ]
+      },
+      response_payload: {}
+    )
+
+    # Verify no PII in persisted interaction
+    interaction = result.interaction
+    payload_json = interaction.request_payload.to_json
+    assert_not_includes payload_json, "test@email.org"
+    assert_includes payload_json, "[EMAIL]"
+    assert_includes payload_json, "[PHONE]"
+  ensure
+    TraceBook.reset_configuration!
+    Tracebook::Interaction.delete_all
+  end
+
+  test "record! serializes actor for job-safe persistence" do
+    TraceBook.reset_configuration!
+    Tracebook::Interaction.delete_all
+    TraceBook.configure do |config|
+      config.persist_async = false
+    end
+
+    actor_class = Class.new do
+      def self.name
+        "TestActor"
+      end
+    end
+    actor = actor_class.new
+    actor.define_singleton_method(:id) { 789 }
+    actor.define_singleton_method(:respond_to?) do |method|
+      method != :to_global_id && super(method)
+    end
+
+    result = TraceBook.record!(
+      provider: "openai",
+      model: "gpt-4o",
+      request_text: "Hello",
+      response_text: "Hi",
+      actor: actor
+    )
+
+    # Actor should be serialized as type/id in the interaction
+    interaction = result.interaction
+    assert_equal "TestActor", interaction.actor_type
+    assert_equal 789, interaction.actor_id
+  ensure
+    TraceBook.reset_configuration!
+    Tracebook::Interaction.delete_all
+  end
+
+  test "record! redaction performance is acceptable" do
+    TraceBook.reset_configuration!
+    Tracebook::Interaction.delete_all
+    TraceBook.configure do |config|
+      config.redact :email, :phone, :credit_card, :ssn
+      config.persist_async = false
+    end
+
+    # Create payload with many fields to redact
+    large_payload = {
+      "messages" => 50.times.map do |i|
+        { "content" => "Email #{i}: user#{i}@test.com, Phone: (555) 123-45#{i.to_s.rjust(2, '0')}" }
+      end
+    }
+
+    start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+    result = TraceBook.record!(
+      provider: "openai",
+      model: "gpt-4o",
+      request_payload: large_payload,
+      response_payload: {}
+    )
+
+    elapsed_ms = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time) * 1000
+
+    # Performance should be under 100ms for regex redaction (database write adds overhead)
+    assert elapsed_ms < 100, "Redaction took #{elapsed_ms.round(2)}ms, should be under 100ms"
+
+    # Verify redaction actually happened
+    assert_not_includes result.interaction.request_payload.to_json, "@test.com"
+  ensure
+    TraceBook.reset_configuration!
+    Tracebook::Interaction.delete_all
+  end
 end


### PR DESCRIPTION
## Summary

Background job for async LLM-based PII redaction with retry policy:

- `LlmRedactionJob` - processes interactions that need LLM-based redaction
- Retry policy: 3 attempts with exponential backoff
- Updates metadata on success/failure
- Skips already-processed interactions
- Pessimistic lock prevents race conditions
- `config.llm_redactor` accessor for configuring the LLM redactor instance

## Test plan

- [x] Test skips when no LLM redactor configured
- [x] Test redacts text and payload fields
- [x] Test skips already processed interactions
- [x] Test records failure on error
- [x] Test increments attempt count on repeated failures
- [x] Test discards job when interaction not found
- [x] Test handles nil payloads gracefully
- [x] Full suite passes (203 tests)

Closes #49, Closes #50